### PR TITLE
Fix error to match output prevalence

### DIFF
--- a/.ipynb_checkpoints/UNSEEN_caseness_cohort_breakdown-checkpoint.ipynb
+++ b/.ipynb_checkpoints/UNSEEN_caseness_cohort_breakdown-checkpoint.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 185,
    "id": "41d1afc3-c12f-42fa-b9cb-3ed36514a7fa",
    "metadata": {
     "jupyter": {
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 186,
    "id": "a1386d0b-56fe-4684-b6f1-ef6e9bab36d3",
    "metadata": {
     "jupyter": {
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 187,
    "id": "d1bf06a3-ba12-422a-8350-b6b7048565e1",
    "metadata": {
     "jupyter": {
@@ -124,15 +124,15 @@
     "    ,columns = [\"Id\"]\n",
     ")\n",
     "\n",
-    "#codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-5ac8d4fa.csv\")\n",
+    "#codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-0e6bb986.csv\")\n",
     "\n",
     "codes_to_query_borderline = pandas.read_csv(folder + \"ciaranmci-borderline-personality-disorder-1ed4af38.csv\")\n",
     "codes_to_query_chronicDepression = pandas.read_csv(folder + \"ciaranmci-chronic-depression-53a65598.csv\")\n",
     "codes_to_query_chronicPTSD = pandas.read_csv(folder + \"ciaranmci-chronic-post-traumatic-stress-disorder-3a96e263.csv\")\n",
     "codes_to_query_complexPTSD = pandas.read_csv(folder + \"ciaranmci-complex-post-traumatic-stress-disorder-21876f2e.csv\")\n",
-    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-50f395a2.csv\")\n",
+    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
     "codes_to_query_dysthymia = pandas.read_csv(folder + \"ciaranmci-dysthymia-6f6888c3.csv\")\n",
-    "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-243a2f24.csv\")\n",
+    "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-5c4cd31b.csv\")\n",
     "\n",
     "# Medications of interest.\n",
     "medications_to_query_psychosisAndRelated = pandas.read_csv(folder + \"UNSEEN_medications_psychosisAndRelated.csv\")\n",
@@ -158,9 +158,9 @@
     "7. Personality disorder\n",
     "\n",
     "The list of component medications are:\n",
-    "1. Medications associated with psychois and related disorders\n",
+    "1. Antidepressants\n",
     "2. Hypnotics and anxiolytics\n",
-    "3. Antidepressants"
+    "3. Medications associated with psychois and related disorders"
    ]
   },
   {
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 188,
    "id": "94fd978d-a789-496b-8b94-9524bcf7398c",
    "metadata": {
     "jupyter": {
@@ -243,12 +243,12 @@
     ")\n",
     "\n",
     "\n",
-    ",tbl_medications_psychosisAndRelated AS (\n",
+    ",tbl_medications_antidepressants AS (\n",
     "    SELECT\n",
     "        my_nameofmedication\n",
     "    FROM\n",
     "        UNNEST([\n",
-    "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_psychosisAndRelated[\"Medication\"].tolist())) + \"\"\"'\n",
+    "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_antidepressants[\"Medication\"].tolist())) + \"\"\"'\n",
     "                ]) AS my_nameofmedication\n",
     ")\n",
     ",tbl_medications_hypnoticsAndAnxiolytics AS (\n",
@@ -259,12 +259,12 @@
     "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_hypnoticsAndAnxiolytics[\"Medication\"].tolist())) + \"\"\"'\n",
     "                ]) AS my_nameofmedication\n",
     ")\n",
-    ",tbl_medications_antidepressants AS (\n",
+    ",tbl_medications_psychosisAndRelated AS (\n",
     "    SELECT\n",
     "        my_nameofmedication\n",
     "    FROM\n",
     "        UNNEST([\n",
-    "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_antidepressants[\"Medication\"].tolist())) + \"\"\"'\n",
+    "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_psychosisAndRelated[\"Medication\"].tolist())) + \"\"\"'\n",
     "                ]) AS my_nameofmedication\n",
     ")\n",
     "\"\"\"\n",
@@ -426,10 +426,10 @@
     ")\n",
     "\n",
     "\n",
-    ",tbl_persons_with_psychosisAndRelated_meds AS (\n",
+    ",tbl_persons_with_antidepressants_meds AS (\n",
     "    SELECT\n",
     "        DISTINCT tbl_persons_firstFilters.person_id\n",
-    "        ,1 AS psychosisAndRelated\n",
+    "        ,1 AS antidepressants\n",
     "    FROM\n",
     "        tbl_persons_firstFilters\n",
     "    # This join is adding the medication table so that I can query medications.\n",
@@ -443,12 +443,12 @@
     "    # easily do a row-wise comparison of the medications of interest with the variously-\n",
     "    # worded `nameofmedication` values in the database.\n",
     "    CROSS JOIN\n",
-    "        tbl_medications_psychosisAndRelated\n",
+    "        tbl_medications_antidepressants\n",
     "    WHERE\n",
     "        # This filters for the medications of interest.\n",
-    "        REGEXP_CONTAINS(nameofmedication, tbl_medications_psychosisAndRelated.my_nameofmedication) = True\n",
+    "        REGEXP_CONTAINS(nameofmedication, tbl_medications_antidepressants.my_nameofmedication) = True\n",
     "        AND\n",
-    "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window) + \"\"\"\n",
+    "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window_caseness) + \"\"\"\n",
     ")\n",
     ",tbl_persons_with_hypnoticsAndAnxiolytics_meds AS (\n",
     "    SELECT\n",
@@ -474,10 +474,10 @@
     "        AND\n",
     "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window) + \"\"\"\n",
     ")\n",
-    ",tbl_persons_with_antidepressants_meds AS (\n",
+    ",tbl_persons_with_psychosisAndRelated_meds AS (\n",
     "    SELECT\n",
     "        DISTINCT tbl_persons_firstFilters.person_id\n",
-    "        ,1 AS antidepressants\n",
+    "        ,1 AS psychosisAndRelated\n",
     "    FROM\n",
     "        tbl_persons_firstFilters\n",
     "    # This join is adding the medication table so that I can query medications.\n",
@@ -491,14 +491,13 @@
     "    # easily do a row-wise comparison of the medications of interest with the variously-\n",
     "    # worded `nameofmedication` values in the database.\n",
     "    CROSS JOIN\n",
-    "        tbl_medications_antidepressants\n",
+    "        tbl_medications_psychosisAndRelated\n",
     "    WHERE\n",
     "        # This filters for the medications of interest.\n",
-    "        REGEXP_CONTAINS(nameofmedication, tbl_medications_antidepressants.my_nameofmedication) = True\n",
+    "        REGEXP_CONTAINS(nameofmedication, tbl_medications_psychosisAndRelated.my_nameofmedication) = True\n",
     "        AND\n",
-    "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window_caseness) + \"\"\"\n",
+    "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window) + \"\"\"\n",
     ")\n",
-    "\n",
     "\n",
     ",tbl_studyPopulation_casenessBreakdown AS (\n",
     "    SELECT\n",
@@ -511,9 +510,9 @@
     "        ,CASE WHEN dysthymia IS NULL THEN 0 ELSE 1 END AS dysthymia\n",
     "        ,CASE WHEN personalityDisorder IS NULL THEN 0 ELSE 1 END AS personalityDisorder\n",
     "        \n",
-    "        ,CASE WHEN psychosisAndRelated IS NULL THEN 0 ELSE 1 END AS psychosisAndRelated\n",
-    "        ,CASE WHEN hypnoticsAndAnxiolytics IS NULL THEN 0 ELSE 1 END AS hypnoticsAndAnxiolytics\n",
     "        ,CASE WHEN antidepressants IS NULL THEN 0 ELSE 1 END AS antidepressants\n",
+    "        ,CASE WHEN hypnoticsAndAnxiolytics IS NULL THEN 0 ELSE 1 END AS hypnoticsAndAnxiolytics\n",
+    "        ,CASE WHEN psychosisAndRelated IS NULL THEN 0 ELSE 1 END AS psychosisAndRelated\n",
     "    FROM\n",
     "        tbl_studyPopulation_no_caseness\n",
     "    LEFT JOIN tbl_persons_with_borderlinePD_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_borderlinePD_codes.person_id\n",
@@ -524,9 +523,9 @@
     "    LEFT JOIN tbl_persons_with_dysthymia_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_dysthymia_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_personalityDisorder_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_personalityDisorder_codes.person_id\n",
     "    \n",
-    "    LEFT JOIN tbl_persons_with_psychosisAndRelated_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_psychosisAndRelated_meds.person_id\n",
-    "    LEFT JOIN tbl_persons_with_hypnoticsAndAnxiolytics_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_hypnoticsAndAnxiolytics_meds.person_id\n",
     "    LEFT JOIN tbl_persons_with_antidepressants_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_antidepressants_meds.person_id\n",
+    "    LEFT JOIN tbl_persons_with_hypnoticsAndAnxiolytics_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_hypnoticsAndAnxiolytics_meds.person_id\n",
+    "    LEFT JOIN tbl_persons_with_psychosisAndRelated_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_psychosisAndRelated_meds.person_id\n",
     ")\n",
     "\"\"\""
    ]
@@ -541,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 189,
    "id": "695bdb56-b89d-45f7-8de0-eb73e80d9614",
    "metadata": {
     "jupyter": {
@@ -568,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 222,
    "id": "8c74d776-95f7-43e4-b881-8cba268710a5",
    "metadata": {
     "jupyter": {
@@ -577,6 +576,13 @@
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mNOTE: The overall proportion of patients satisfying caseness is 2.4%\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -598,6 +604,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>counts</th>\n",
        "      <th>proportion</th>\n",
        "      <th>prevalence_per_thousand</th>\n",
        "    </tr>\n",
@@ -605,70 +612,80 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>borderlinePD</th>\n",
+       "      <td>490.0</td>\n",
        "      <td>0.24</td>\n",
        "      <td>2.36</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>chronicDepression</th>\n",
+       "      <td>1180.0</td>\n",
        "      <td>0.57</td>\n",
        "      <td>5.67</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>chronicPTSD</th>\n",
+       "      <td>120.0</td>\n",
        "      <td>0.06</td>\n",
        "      <td>0.58</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>complexPTSD</th>\n",
+       "      <td>0.0</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>devAcademicDisorder</th>\n",
+       "      <td>1790.0</td>\n",
        "      <td>0.86</td>\n",
        "      <td>8.61</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>dysthymia</th>\n",
+       "      <td>520.0</td>\n",
        "      <td>0.25</td>\n",
        "      <td>2.50</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>personalityDisorder</th>\n",
+       "      <td>3650.0</td>\n",
        "      <td>1.75</td>\n",
        "      <td>17.55</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>psychosisAndRelated</th>\n",
-       "      <td>4.68</td>\n",
-       "      <td>46.82</td>\n",
+       "      <th>antidepressants</th>\n",
+       "      <td>130520.0</td>\n",
+       "      <td>62.75</td>\n",
+       "      <td>627.47</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>hypnoticsAndAnxiolytics</th>\n",
+       "      <td>55700.0</td>\n",
        "      <td>26.78</td>\n",
        "      <td>267.78</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>antidepressants</th>\n",
-       "      <td>62.75</td>\n",
-       "      <td>627.47</td>\n",
+       "      <th>psychosisAndRelated</th>\n",
+       "      <td>9740.0</td>\n",
+       "      <td>4.68</td>\n",
+       "      <td>46.82</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                         proportion  prevalence_per_thousand\n",
-       "borderlinePD                   0.24                     2.36\n",
-       "chronicDepression              0.57                     5.67\n",
-       "chronicPTSD                    0.06                     0.58\n",
-       "complexPTSD                    0.00                     0.00\n",
-       "devAcademicDisorder            0.86                     8.61\n",
-       "dysthymia                      0.25                     2.50\n",
-       "personalityDisorder            1.75                    17.55\n",
-       "psychosisAndRelated            4.68                    46.82\n",
-       "hypnoticsAndAnxiolytics       26.78                   267.78\n",
-       "antidepressants               62.75                   627.47"
+       "                           counts  proportion  prevalence_per_thousand\n",
+       "borderlinePD                490.0        0.24                     2.36\n",
+       "chronicDepression          1180.0        0.57                     5.67\n",
+       "chronicPTSD                 120.0        0.06                     0.58\n",
+       "complexPTSD                   0.0        0.00                     0.00\n",
+       "devAcademicDisorder        1790.0        0.86                     8.61\n",
+       "dysthymia                   520.0        0.25                     2.50\n",
+       "personalityDisorder        3650.0        1.75                    17.55\n",
+       "antidepressants          130520.0       62.75                   627.47\n",
+       "hypnoticsAndAnxiolytics   55700.0       26.78                   267.78\n",
+       "psychosisAndRelated        9740.0        4.68                    46.82"
       ]
      },
      "metadata": {},
@@ -677,10 +694,235 @@
    ],
    "source": [
     "counts_components = round(caseness_breakdown_array.iloc[:,1:].sum() / target_round) * target_round\n",
-    "#[counts_components / count_studyPopulation]\n",
     "proportion = round((counts_components / count_studyPopulation) * 100, 2 )\n",
     "prevalence_per_thousand = round((counts_components / count_studyPopulation) * 1000, 2 )\n",
-    "display( pandas.DataFrame(data = {'proportion' : proportion, 'prevalence_per_thousand' : prevalence_per_thousand} ) )"
+    "\n",
+    "print(f'\\033[1mNOTE: The overall proportion of patients satisfying caseness is {round((round(len(caseness_breakdown_array.loc[(count_of_diagnoses > 0) & (count_of_medications > 0),:]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "\n",
+    "display( pandas.DataFrame(data = {'counts' : counts_components, 'proportion' : proportion, 'prevalence_per_thousand' : prevalence_per_thousand} ) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "474b5ffb-d2c3-4f96-a804-1b0bfa651805",
+   "metadata": {},
+   "source": [
+    "### Proportion with each count of diagnoses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 230,
+   "id": "4d346a7b-3f7d-41ef-aa52-784cff67c938",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mNOTE: The proportion of patients with at least one diagnosis is 3.35%\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count_with_each_count_of_diagnoses</th>\n",
+       "      <th>proportion_with_each_count_of_diagnoses</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0.0</th>\n",
+       "      <td>201050.0</td>\n",
+       "      <td>96.65</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>6220.0</td>\n",
+       "      <td>2.99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2.0</th>\n",
+       "      <td>680.0</td>\n",
+       "      <td>0.33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3.0</th>\n",
+       "      <td>60.0</td>\n",
+       "      <td>0.03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4.0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     count_with_each_count_of_diagnoses  \\\n",
+       "0.0                            201050.0   \n",
+       "1.0                              6220.0   \n",
+       "2.0                               680.0   \n",
+       "3.0                                60.0   \n",
+       "4.0                                 0.0   \n",
+       "\n",
+       "     proportion_with_each_count_of_diagnoses  \n",
+       "0.0                                    96.65  \n",
+       "1.0                                     2.99  \n",
+       "2.0                                     0.33  \n",
+       "3.0                                     0.03  \n",
+       "4.0                                     0.00  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "caseness_breakdown_array['count_of_diagnoses'] = pandas.DataFrame( caseness_breakdown_array.loc[:, ~caseness_breakdown_array.columns.isin(['person_id', 'antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated'])].sum(axis = 1), columns = ['count_of_diagnoses'] )\n",
+    "caseness_breakdown_array['count_of_medications'] = pandas.DataFrame( caseness_breakdown_array.loc[:,['antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated']].sum(axis = 1), columns = ['count_of_medications'] )\n",
+    "\n",
+    "print(f'\\033[1mNOTE: The proportion of patients with at least one diagnosis is {round((round(len(caseness_breakdown_array.loc[(count_of_diagnoses > 0)]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "\n",
+    "display(\n",
+    "    pandas.DataFrame(\n",
+    "        data = {\n",
+    "            'count_with_each_count_of_diagnoses' : round(caseness_breakdown_array.count_of_diagnoses.value_counts() / target_round) * target_round,\n",
+    "            'proportion_with_each_count_of_diagnoses' : round(round(caseness_breakdown_array.count_of_diagnoses.value_counts() / target_round) * target_round / count_studyPopulation * 100,2)\n",
+    "        }\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de7b3049-a47d-4358-90f5-5c190bb41838",
+   "metadata": {},
+   "source": [
+    "### Proportion with each count of medication (note that 0 is not the largest)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 231,
+   "id": "dea9fb1d-1757-4e69-8f8a-32038fa42ce2",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mNOTE: The proportion of patients with at least one medication is 73.07%\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count_with_each_count_of_medications</th>\n",
+       "      <th>proportion_with_each_count_of_medications</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>112350.0</td>\n",
+       "      <td>54.01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.0</th>\n",
+       "      <td>56010.0</td>\n",
+       "      <td>26.93</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2.0</th>\n",
+       "      <td>35340.0</td>\n",
+       "      <td>16.99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3.0</th>\n",
+       "      <td>4310.0</td>\n",
+       "      <td>2.07</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     count_with_each_count_of_medications  \\\n",
+       "1.0                              112350.0   \n",
+       "0.0                               56010.0   \n",
+       "2.0                               35340.0   \n",
+       "3.0                                4310.0   \n",
+       "\n",
+       "     proportion_with_each_count_of_medications  \n",
+       "1.0                                      54.01  \n",
+       "0.0                                      26.93  \n",
+       "2.0                                      16.99  \n",
+       "3.0                                       2.07  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(f'\\033[1mNOTE: The proportion of patients with at least one medication is {round((round(len(caseness_breakdown_array.loc[(count_of_medications > 0)]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "display(\n",
+    "    pandas.DataFrame(\n",
+    "        data = {\n",
+    "            'count_with_each_count_of_medications' : round(caseness_breakdown_array.count_of_medications.value_counts() / target_round) * target_round,\n",
+    "            'proportion_with_each_count_of_medications' : round(round(caseness_breakdown_array.count_of_medications.value_counts() / target_round) * target_round / count_studyPopulation * 100,2)\n",
+    "        }\n",
+    "    )\n",
+    ")"
    ]
   }
  ],

--- a/.ipynb_checkpoints/UNSEEN_create_caseness_variables-checkpoint.ipynb
+++ b/.ipynb_checkpoints/UNSEEN_create_caseness_variables-checkpoint.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 23,
    "id": "b476962c-70f3-413c-905e-b784dcc9bb93",
    "metadata": {
     "jupyter": {
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 24,
    "id": "089b7cb6-957f-4845-8f26-6f1d446a8912",
    "metadata": {
     "jupyter": {
@@ -49,16 +49,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.7/site-packages/google/auth/_default.py:78: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
-      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n",
-      "/opt/conda/lib/python3.7/site-packages/google/auth/_default.py:78: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
-      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -93,9 +83,6 @@
     "global database_id\n",
     "database_id = 'CB_FDM_PrimaryCare_V7'\n",
     "\n",
-    "# Instantiate BigQuery client.\n",
-    "client = bigquery.Client()\n",
-    "\n",
     "# Set folder location.\n",
     "folder_loc = os.path.dirname(os.path.abspath(\"UNSEEN create caseness array.ipynb\"))\n",
     "folder = folder_loc + '/codelists/'\n",
@@ -114,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 27,
    "id": "3fc23759-0e6c-4fe4-9d1c-008db17a1825",
    "metadata": {
     "jupyter": {
@@ -139,14 +126,25 @@
     "    ,columns = [\"Id\"]\n",
     ")\n",
     "\n",
-    "codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-5ac8d4fa.csv\")\n",
+    "codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-0e6bb986.csv\")\n",
+    "codes_to_query_caseness = pandas.DataFrame(\n",
+    "    list(\n",
+    "        set(codes_to_query_caseness[\"code\"]).difference(\n",
+    "            set(codes_to_query_bipolar[\"code\"]).union(\n",
+    "                set(codes_to_query_schizophrenia[\"code\"])\n",
+    "            )\n",
+    "        )\n",
+    "    )\n",
+    "    ,columns = [\"code\"]\n",
+    ")\n",
     "\n",
     "codes_to_query_borderline = pandas.read_csv(folder + \"ciaranmci-borderline-personality-disorder-1ed4af38.csv\")\n",
     "codes_to_query_chronicDepression = pandas.read_csv(folder + \"ciaranmci-chronic-depression-53a65598.csv\")\n",
     "codes_to_query_chronicPTSD = pandas.read_csv(folder + \"ciaranmci-chronic-post-traumatic-stress-disorder-3a96e263.csv\")\n",
     "codes_to_query_complexPTSD = pandas.read_csv(folder + \"ciaranmci-complex-post-traumatic-stress-disorder-21876f2e.csv\")\n",
+    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
     "codes_to_query_dysthymia = pandas.read_csv(folder + \"ciaranmci-dysthymia-6f6888c3.csv\")\n",
-    "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-243a2f24.csv\")\n",
+    "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-5c4cd31b.csv\")\n",
     "\n",
     "# Medications of interest.\n",
     "medications_to_query_psychosisAndRelated = pandas.read_csv(folder + \"UNSEEN_medications_psychosisAndRelated.csv\")\n",
@@ -164,7 +162,7 @@
     "\n",
     "I first specify the population of interest with `person_id` values. These `person_id` values are filtered as follows:\n",
     "1. all people with a `person_id` in Connected Bradford's primary-care table,\n",
-    "2. aged between 18 and 70, inclusive, as of today's date (note: today's date is used rather than the `myIndexDate` date because this filter is for ethical research rather),\n",
+    "2. aged between 18 and 70, inclusive, as of today's date (note: today's date is used rather than the `myIndexDate` date),\n",
     "3. who have been registered with their practice for at least `min_GP_registeration_duration` years,\n",
     "4. who have a record of a SNOMED-CT diagnostic code from `codes_to_query_mentalIllHealth` within `Dx_windows` years prior to the `myIndexDate` date, or who have a record of prescriptions for medicines from `medications_to_query_all` within `Rx_windows` years prior to the `myIndexDate` date,\n",
     "5. excluding those people who have a record of a SNOMED-CT diagnostic code from `codes_to_query_schizophrenia` or `codes_to_query_bipolar`.\n",
@@ -174,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 28,
    "id": "bc365b3f-cca3-481b-b173-c2aceef40979",
    "metadata": {
     "jupyter": {
@@ -327,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 30,
    "id": "2c383190-8162-4a7c-8999-24f53f227412",
    "metadata": {
     "jupyter": {
@@ -371,7 +369,7 @@
     ")\n",
     ",tbl_persons_with_caseness_codes_and_medications AS (\n",
     "    SELECT\n",
-    "        tbl_persons_with_caseness_codes.person_id\n",
+    "        DISTINCT tbl_persons_with_caseness_codes.person_id\n",
     "        ,1 AS caseness_1isYes\n",
     "    FROM\n",
     "        tbl_persons_with_caseness_codes\n",
@@ -381,7 +379,7 @@
     ")\n",
     ",tbl_studyPopulation AS (\n",
     "    SELECT\n",
-    "        tbl_studyPopulation_no_caseness.person_id\n",
+    "        DISTINCT tbl_studyPopulation_no_caseness.person_id\n",
     "        ,CASE WHEN caseness_1isYes IS NULL THEN 0 ELSE 1 END AS caseness_1isYes\n",
     "    FROM\n",
     "        tbl_studyPopulation_no_caseness\n",
@@ -402,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 32,
    "id": "d75ca821-6440-44e1-b56f-a85ed244b659",
    "metadata": {
     "jupyter": {
@@ -412,18 +410,10 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.7/site-packages/google/auth/_default.py:78: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
-      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The prevalence of caseness among those with mental ill-health in the Connected Bradford dataset is \u001b[1m3.8%\u001b[0m. \n",
+      "The prevalence of caseness among those with mental ill-health in the Connected Bradford dataset is \u001b[1m2.4%\u001b[0m. \n",
       "\n",
       "Stored 'sql_declarations' (str)\n",
       "Stored 'sql_studyPopulation' (str)\n",
@@ -475,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 33,
    "id": "1461cc80-5008-4c77-a517-7b2d55171fa9",
    "metadata": {
     "jupyter": {
@@ -490,8 +480,8 @@
      "text": [
       "\n",
       " Calculating the entropy of the caseness variable in nats...\n",
-      "\t Caseness variable entropy = 0.161 nats\n",
-      "\t The caseness variable's entropy is 23.3 % of its theoretical maximum\n",
+      "\t Caseness variable entropy = 0.114 nats\n",
+      "\t The caseness variable's entropy is 16.4 % of its theoretical maximum\n",
       "\n"
      ]
     }
@@ -513,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 34,
    "id": "26f39a30-0d49-4a50-9979-1061f88568be",
    "metadata": {
     "jupyter": {
@@ -528,9 +518,9 @@
      "text": [
       "\n",
       " Calculating the hit rates of the caseness variable in nats...\n",
-      "\t Hit rate (all) = 3.79 %\n",
-      "\t Hit rate (none) = 96.21 %\n",
-      "\t Odds (No : Yes) = 25-times less likely to demonstrate caseness than to not.\n"
+      "\t Hit rate (all) = 2.416 %\n",
+      "\t Hit rate (none) = 97.584 %\n",
+      "\t Odds (No : Yes) = 40-times less likely to demonstrate caseness than to not.\n"
      ]
     }
    ],
@@ -549,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 35,
    "id": "93514baa-1ae5-4a42-a8db-40b1d03d44b1",
    "metadata": {
     "jupyter": {
@@ -563,15 +553,15 @@
       "text/markdown": [
        "    \n",
        "We now know that:\n",
-       "1. based on the scaled entropy, our variable indicating the caseness of complex mental health difficulties is $\\le23.3\\%$ as uncertain/surprising/unforeseeable\n",
+       "1. based on the scaled entropy, our variable indicating the caseness of complex mental health difficulties is $\\le16.4\\%$ as uncertain/surprising/unforeseeable\n",
        "as it could possibly be; _and_\n",
        "\n",
-       "2. we would correctly classify $\\ge96.2\\%$ of patients in this sample if we simply assumed that no one has complex mental health difficulties.\n",
+       "2. we would correctly classify $\\ge97.6\\%$ of patients in this sample if we simply assumed that no one has complex mental health difficulties.\n",
        "\n",
        "The first point tells us that definite caseness of complex mental health difficulties can be known with considerable certainty, in this dataset. There is only so much room for improvement via feature sets.\n",
        "\n",
        "The second point defines a benchmark for the indicative performance of any feature set that we evaluate in our study. Specifically, any feature set that we suggest to improve our certainty of knowing\n",
-       "that someone has complex mental health difficulties must correctly identify $\\ge96.2\\%$ of patients in our sample. Otherwise, the added feature set is a needless\n",
+       "that someone has complex mental health difficulties must correctly identify $\\ge97.6\\%$ of patients in our sample. Otherwise, the added feature set is a needless\n",
        "complication to our attempt to know whether or not someone has complex mental health difficulties (which we can often safely assume they don't). This is such a high benchmark that we will be very\n",
        "unlikely to find such a feature set.\n",
        "\n",
@@ -614,7 +604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 36,
    "id": "e6d784e3-f641-425c-84f5-fb0e596d6f66",
    "metadata": {
     "jupyter": {
@@ -632,10 +622,10 @@
        "| Statistic                      |    Value   |\n",
        "| ------------------------------ | -----------|\n",
        "| Normalised mutual information  | x → 0 |\n",
-       "| Class balance accuracy         | 0.48      |\n",
+       "| Class balance accuracy         | 0.49      |\n",
        "| Odds ratio                     | Not a number because one of the odds is zero.       |\n",
        "| Positive predictive value      | 0      |\n",
-       "| Negative predictive value      | 0.96      |\n",
+       "| Negative predictive value      | 0.98      |\n",
        "\n"
       ],
       "text/plain": [

--- a/UNSEEN_caseness_cohort_breakdown.ipynb
+++ b/UNSEEN_caseness_cohort_breakdown.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 185,
    "id": "41d1afc3-c12f-42fa-b9cb-3ed36514a7fa",
    "metadata": {
     "jupyter": {
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 186,
    "id": "a1386d0b-56fe-4684-b6f1-ef6e9bab36d3",
    "metadata": {
     "jupyter": {
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 187,
    "id": "d1bf06a3-ba12-422a-8350-b6b7048565e1",
    "metadata": {
     "jupyter": {
@@ -124,15 +124,15 @@
     "    ,columns = [\"Id\"]\n",
     ")\n",
     "\n",
-    "#codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-5ac8d4fa.csv\")\n",
+    "#codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-0e6bb986.csv\")\n",
     "\n",
     "codes_to_query_borderline = pandas.read_csv(folder + \"ciaranmci-borderline-personality-disorder-1ed4af38.csv\")\n",
     "codes_to_query_chronicDepression = pandas.read_csv(folder + \"ciaranmci-chronic-depression-53a65598.csv\")\n",
     "codes_to_query_chronicPTSD = pandas.read_csv(folder + \"ciaranmci-chronic-post-traumatic-stress-disorder-3a96e263.csv\")\n",
     "codes_to_query_complexPTSD = pandas.read_csv(folder + \"ciaranmci-complex-post-traumatic-stress-disorder-21876f2e.csv\")\n",
-    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-50f395a2.csv\")\n",
+    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
     "codes_to_query_dysthymia = pandas.read_csv(folder + \"ciaranmci-dysthymia-6f6888c3.csv\")\n",
-    "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-243a2f24.csv\")\n",
+    "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-5c4cd31b.csv\")\n",
     "\n",
     "# Medications of interest.\n",
     "medications_to_query_psychosisAndRelated = pandas.read_csv(folder + \"UNSEEN_medications_psychosisAndRelated.csv\")\n",
@@ -158,9 +158,9 @@
     "7. Personality disorder\n",
     "\n",
     "The list of component medications are:\n",
-    "1. Medications associated with psychois and related disorders\n",
+    "1. Antidepressants\n",
     "2. Hypnotics and anxiolytics\n",
-    "3. Antidepressants"
+    "3. Medications associated with psychois and related disorders"
    ]
   },
   {
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 188,
    "id": "94fd978d-a789-496b-8b94-9524bcf7398c",
    "metadata": {
     "jupyter": {
@@ -243,12 +243,12 @@
     ")\n",
     "\n",
     "\n",
-    ",tbl_medications_psychosisAndRelated AS (\n",
+    ",tbl_medications_antidepressants AS (\n",
     "    SELECT\n",
     "        my_nameofmedication\n",
     "    FROM\n",
     "        UNNEST([\n",
-    "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_psychosisAndRelated[\"Medication\"].tolist())) + \"\"\"'\n",
+    "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_antidepressants[\"Medication\"].tolist())) + \"\"\"'\n",
     "                ]) AS my_nameofmedication\n",
     ")\n",
     ",tbl_medications_hypnoticsAndAnxiolytics AS (\n",
@@ -259,12 +259,12 @@
     "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_hypnoticsAndAnxiolytics[\"Medication\"].tolist())) + \"\"\"'\n",
     "                ]) AS my_nameofmedication\n",
     ")\n",
-    ",tbl_medications_antidepressants AS (\n",
+    ",tbl_medications_psychosisAndRelated AS (\n",
     "    SELECT\n",
     "        my_nameofmedication\n",
     "    FROM\n",
     "        UNNEST([\n",
-    "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_antidepressants[\"Medication\"].tolist())) + \"\"\"'\n",
+    "                '\"\"\" + '\\', \\''.join(map(str, medications_to_query_psychosisAndRelated[\"Medication\"].tolist())) + \"\"\"'\n",
     "                ]) AS my_nameofmedication\n",
     ")\n",
     "\"\"\"\n",
@@ -426,10 +426,10 @@
     ")\n",
     "\n",
     "\n",
-    ",tbl_persons_with_psychosisAndRelated_meds AS (\n",
+    ",tbl_persons_with_antidepressants_meds AS (\n",
     "    SELECT\n",
     "        DISTINCT tbl_persons_firstFilters.person_id\n",
-    "        ,1 AS psychosisAndRelated\n",
+    "        ,1 AS antidepressants\n",
     "    FROM\n",
     "        tbl_persons_firstFilters\n",
     "    # This join is adding the medication table so that I can query medications.\n",
@@ -443,12 +443,12 @@
     "    # easily do a row-wise comparison of the medications of interest with the variously-\n",
     "    # worded `nameofmedication` values in the database.\n",
     "    CROSS JOIN\n",
-    "        tbl_medications_psychosisAndRelated\n",
+    "        tbl_medications_antidepressants\n",
     "    WHERE\n",
     "        # This filters for the medications of interest.\n",
-    "        REGEXP_CONTAINS(nameofmedication, tbl_medications_psychosisAndRelated.my_nameofmedication) = True\n",
+    "        REGEXP_CONTAINS(nameofmedication, tbl_medications_antidepressants.my_nameofmedication) = True\n",
     "        AND\n",
-    "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window) + \"\"\"\n",
+    "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window_caseness) + \"\"\"\n",
     ")\n",
     ",tbl_persons_with_hypnoticsAndAnxiolytics_meds AS (\n",
     "    SELECT\n",
@@ -474,10 +474,10 @@
     "        AND\n",
     "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window) + \"\"\"\n",
     ")\n",
-    ",tbl_persons_with_antidepressants_meds AS (\n",
+    ",tbl_persons_with_psychosisAndRelated_meds AS (\n",
     "    SELECT\n",
     "        DISTINCT tbl_persons_firstFilters.person_id\n",
-    "        ,1 AS antidepressants\n",
+    "        ,1 AS psychosisAndRelated\n",
     "    FROM\n",
     "        tbl_persons_firstFilters\n",
     "    # This join is adding the medication table so that I can query medications.\n",
@@ -491,14 +491,13 @@
     "    # easily do a row-wise comparison of the medications of interest with the variously-\n",
     "    # worded `nameofmedication` values in the database.\n",
     "    CROSS JOIN\n",
-    "        tbl_medications_antidepressants\n",
+    "        tbl_medications_psychosisAndRelated\n",
     "    WHERE\n",
     "        # This filters for the medications of interest.\n",
-    "        REGEXP_CONTAINS(nameofmedication, tbl_medications_antidepressants.my_nameofmedication) = True\n",
+    "        REGEXP_CONTAINS(nameofmedication, tbl_medications_psychosisAndRelated.my_nameofmedication) = True\n",
     "        AND\n",
-    "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window_caseness) + \"\"\"\n",
+    "        DATE_DIFF(myIndexDate, CAST(tbl_srprimarycaremedication.datemedicationstart AS DATE), YEAR) BETWEEN 0 AND \"\"\" + str(Rx_window) + \"\"\"\n",
     ")\n",
-    "\n",
     "\n",
     ",tbl_studyPopulation_casenessBreakdown AS (\n",
     "    SELECT\n",
@@ -511,9 +510,9 @@
     "        ,CASE WHEN dysthymia IS NULL THEN 0 ELSE 1 END AS dysthymia\n",
     "        ,CASE WHEN personalityDisorder IS NULL THEN 0 ELSE 1 END AS personalityDisorder\n",
     "        \n",
-    "        ,CASE WHEN psychosisAndRelated IS NULL THEN 0 ELSE 1 END AS psychosisAndRelated\n",
-    "        ,CASE WHEN hypnoticsAndAnxiolytics IS NULL THEN 0 ELSE 1 END AS hypnoticsAndAnxiolytics\n",
     "        ,CASE WHEN antidepressants IS NULL THEN 0 ELSE 1 END AS antidepressants\n",
+    "        ,CASE WHEN hypnoticsAndAnxiolytics IS NULL THEN 0 ELSE 1 END AS hypnoticsAndAnxiolytics\n",
+    "        ,CASE WHEN psychosisAndRelated IS NULL THEN 0 ELSE 1 END AS psychosisAndRelated\n",
     "    FROM\n",
     "        tbl_studyPopulation_no_caseness\n",
     "    LEFT JOIN tbl_persons_with_borderlinePD_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_borderlinePD_codes.person_id\n",
@@ -524,9 +523,9 @@
     "    LEFT JOIN tbl_persons_with_dysthymia_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_dysthymia_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_personalityDisorder_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_personalityDisorder_codes.person_id\n",
     "    \n",
-    "    LEFT JOIN tbl_persons_with_psychosisAndRelated_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_psychosisAndRelated_meds.person_id\n",
-    "    LEFT JOIN tbl_persons_with_hypnoticsAndAnxiolytics_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_hypnoticsAndAnxiolytics_meds.person_id\n",
     "    LEFT JOIN tbl_persons_with_antidepressants_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_antidepressants_meds.person_id\n",
+    "    LEFT JOIN tbl_persons_with_hypnoticsAndAnxiolytics_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_hypnoticsAndAnxiolytics_meds.person_id\n",
+    "    LEFT JOIN tbl_persons_with_psychosisAndRelated_meds ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_psychosisAndRelated_meds.person_id\n",
     ")\n",
     "\"\"\""
    ]
@@ -541,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 189,
    "id": "695bdb56-b89d-45f7-8de0-eb73e80d9614",
    "metadata": {
     "jupyter": {
@@ -568,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 222,
    "id": "8c74d776-95f7-43e4-b881-8cba268710a5",
    "metadata": {
     "jupyter": {
@@ -577,6 +576,13 @@
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mNOTE: The overall proportion of patients satisfying caseness is 2.4%\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -598,6 +604,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>counts</th>\n",
        "      <th>proportion</th>\n",
        "      <th>prevalence_per_thousand</th>\n",
        "    </tr>\n",
@@ -605,70 +612,80 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>borderlinePD</th>\n",
+       "      <td>490.0</td>\n",
        "      <td>0.24</td>\n",
        "      <td>2.36</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>chronicDepression</th>\n",
+       "      <td>1180.0</td>\n",
        "      <td>0.57</td>\n",
        "      <td>5.67</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>chronicPTSD</th>\n",
+       "      <td>120.0</td>\n",
        "      <td>0.06</td>\n",
        "      <td>0.58</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>complexPTSD</th>\n",
+       "      <td>0.0</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>devAcademicDisorder</th>\n",
+       "      <td>1790.0</td>\n",
        "      <td>0.86</td>\n",
        "      <td>8.61</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>dysthymia</th>\n",
+       "      <td>520.0</td>\n",
        "      <td>0.25</td>\n",
        "      <td>2.50</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>personalityDisorder</th>\n",
+       "      <td>3650.0</td>\n",
        "      <td>1.75</td>\n",
        "      <td>17.55</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>psychosisAndRelated</th>\n",
-       "      <td>4.68</td>\n",
-       "      <td>46.82</td>\n",
+       "      <th>antidepressants</th>\n",
+       "      <td>130520.0</td>\n",
+       "      <td>62.75</td>\n",
+       "      <td>627.47</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>hypnoticsAndAnxiolytics</th>\n",
+       "      <td>55700.0</td>\n",
        "      <td>26.78</td>\n",
        "      <td>267.78</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>antidepressants</th>\n",
-       "      <td>62.75</td>\n",
-       "      <td>627.47</td>\n",
+       "      <th>psychosisAndRelated</th>\n",
+       "      <td>9740.0</td>\n",
+       "      <td>4.68</td>\n",
+       "      <td>46.82</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                         proportion  prevalence_per_thousand\n",
-       "borderlinePD                   0.24                     2.36\n",
-       "chronicDepression              0.57                     5.67\n",
-       "chronicPTSD                    0.06                     0.58\n",
-       "complexPTSD                    0.00                     0.00\n",
-       "devAcademicDisorder            0.86                     8.61\n",
-       "dysthymia                      0.25                     2.50\n",
-       "personalityDisorder            1.75                    17.55\n",
-       "psychosisAndRelated            4.68                    46.82\n",
-       "hypnoticsAndAnxiolytics       26.78                   267.78\n",
-       "antidepressants               62.75                   627.47"
+       "                           counts  proportion  prevalence_per_thousand\n",
+       "borderlinePD                490.0        0.24                     2.36\n",
+       "chronicDepression          1180.0        0.57                     5.67\n",
+       "chronicPTSD                 120.0        0.06                     0.58\n",
+       "complexPTSD                   0.0        0.00                     0.00\n",
+       "devAcademicDisorder        1790.0        0.86                     8.61\n",
+       "dysthymia                   520.0        0.25                     2.50\n",
+       "personalityDisorder        3650.0        1.75                    17.55\n",
+       "antidepressants          130520.0       62.75                   627.47\n",
+       "hypnoticsAndAnxiolytics   55700.0       26.78                   267.78\n",
+       "psychosisAndRelated        9740.0        4.68                    46.82"
       ]
      },
      "metadata": {},
@@ -677,10 +694,235 @@
    ],
    "source": [
     "counts_components = round(caseness_breakdown_array.iloc[:,1:].sum() / target_round) * target_round\n",
-    "#[counts_components / count_studyPopulation]\n",
     "proportion = round((counts_components / count_studyPopulation) * 100, 2 )\n",
     "prevalence_per_thousand = round((counts_components / count_studyPopulation) * 1000, 2 )\n",
-    "display( pandas.DataFrame(data = {'proportion' : proportion, 'prevalence_per_thousand' : prevalence_per_thousand} ) )"
+    "\n",
+    "print(f'\\033[1mNOTE: The overall proportion of patients satisfying caseness is {round((round(len(caseness_breakdown_array.loc[(count_of_diagnoses > 0) & (count_of_medications > 0),:]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "\n",
+    "display( pandas.DataFrame(data = {'counts' : counts_components, 'proportion' : proportion, 'prevalence_per_thousand' : prevalence_per_thousand} ) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "474b5ffb-d2c3-4f96-a804-1b0bfa651805",
+   "metadata": {},
+   "source": [
+    "### Proportion with each count of diagnoses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 230,
+   "id": "4d346a7b-3f7d-41ef-aa52-784cff67c938",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mNOTE: The proportion of patients with at least one diagnosis is 3.35%\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count_with_each_count_of_diagnoses</th>\n",
+       "      <th>proportion_with_each_count_of_diagnoses</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0.0</th>\n",
+       "      <td>201050.0</td>\n",
+       "      <td>96.65</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>6220.0</td>\n",
+       "      <td>2.99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2.0</th>\n",
+       "      <td>680.0</td>\n",
+       "      <td>0.33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3.0</th>\n",
+       "      <td>60.0</td>\n",
+       "      <td>0.03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4.0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     count_with_each_count_of_diagnoses  \\\n",
+       "0.0                            201050.0   \n",
+       "1.0                              6220.0   \n",
+       "2.0                               680.0   \n",
+       "3.0                                60.0   \n",
+       "4.0                                 0.0   \n",
+       "\n",
+       "     proportion_with_each_count_of_diagnoses  \n",
+       "0.0                                    96.65  \n",
+       "1.0                                     2.99  \n",
+       "2.0                                     0.33  \n",
+       "3.0                                     0.03  \n",
+       "4.0                                     0.00  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "caseness_breakdown_array['count_of_diagnoses'] = pandas.DataFrame( caseness_breakdown_array.loc[:, ~caseness_breakdown_array.columns.isin(['person_id', 'antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated'])].sum(axis = 1), columns = ['count_of_diagnoses'] )\n",
+    "caseness_breakdown_array['count_of_medications'] = pandas.DataFrame( caseness_breakdown_array.loc[:,['antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated']].sum(axis = 1), columns = ['count_of_medications'] )\n",
+    "\n",
+    "print(f'\\033[1mNOTE: The proportion of patients with at least one diagnosis is {round((round(len(caseness_breakdown_array.loc[(count_of_diagnoses > 0)]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "\n",
+    "display(\n",
+    "    pandas.DataFrame(\n",
+    "        data = {\n",
+    "            'count_with_each_count_of_diagnoses' : round(caseness_breakdown_array.count_of_diagnoses.value_counts() / target_round) * target_round,\n",
+    "            'proportion_with_each_count_of_diagnoses' : round(round(caseness_breakdown_array.count_of_diagnoses.value_counts() / target_round) * target_round / count_studyPopulation * 100,2)\n",
+    "        }\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de7b3049-a47d-4358-90f5-5c190bb41838",
+   "metadata": {},
+   "source": [
+    "### Proportion with each count of medication (note that 0 is not the largest)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 231,
+   "id": "dea9fb1d-1757-4e69-8f8a-32038fa42ce2",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mNOTE: The proportion of patients with at least one medication is 73.07%\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count_with_each_count_of_medications</th>\n",
+       "      <th>proportion_with_each_count_of_medications</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>112350.0</td>\n",
+       "      <td>54.01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.0</th>\n",
+       "      <td>56010.0</td>\n",
+       "      <td>26.93</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2.0</th>\n",
+       "      <td>35340.0</td>\n",
+       "      <td>16.99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3.0</th>\n",
+       "      <td>4310.0</td>\n",
+       "      <td>2.07</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     count_with_each_count_of_medications  \\\n",
+       "1.0                              112350.0   \n",
+       "0.0                               56010.0   \n",
+       "2.0                               35340.0   \n",
+       "3.0                                4310.0   \n",
+       "\n",
+       "     proportion_with_each_count_of_medications  \n",
+       "1.0                                      54.01  \n",
+       "0.0                                      26.93  \n",
+       "2.0                                      16.99  \n",
+       "3.0                                       2.07  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(f'\\033[1mNOTE: The proportion of patients with at least one medication is {round((round(len(caseness_breakdown_array.loc[(count_of_medications > 0)]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "display(\n",
+    "    pandas.DataFrame(\n",
+    "        data = {\n",
+    "            'count_with_each_count_of_medications' : round(caseness_breakdown_array.count_of_medications.value_counts() / target_round) * target_round,\n",
+    "            'proportion_with_each_count_of_medications' : round(round(caseness_breakdown_array.count_of_medications.value_counts() / target_round) * target_round / count_studyPopulation * 100,2)\n",
+    "        }\n",
+    "    )\n",
+    ")"
    ]
   }
  ],

--- a/UNSEEN_create_caseness_variables.ipynb
+++ b/UNSEEN_create_caseness_variables.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 23,
    "id": "b476962c-70f3-413c-905e-b784dcc9bb93",
    "metadata": {
     "jupyter": {
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 24,
    "id": "089b7cb6-957f-4845-8f26-6f1d446a8912",
    "metadata": {
     "jupyter": {
@@ -49,16 +49,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.7/site-packages/google/auth/_default.py:78: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
-      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n",
-      "/opt/conda/lib/python3.7/site-packages/google/auth/_default.py:78: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
-      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -93,9 +83,6 @@
     "global database_id\n",
     "database_id = 'CB_FDM_PrimaryCare_V7'\n",
     "\n",
-    "# Instantiate BigQuery client.\n",
-    "client = bigquery.Client()\n",
-    "\n",
     "# Set folder location.\n",
     "folder_loc = os.path.dirname(os.path.abspath(\"UNSEEN create caseness array.ipynb\"))\n",
     "folder = folder_loc + '/codelists/'\n",
@@ -114,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 27,
    "id": "3fc23759-0e6c-4fe4-9d1c-008db17a1825",
    "metadata": {
     "jupyter": {
@@ -139,14 +126,25 @@
     "    ,columns = [\"Id\"]\n",
     ")\n",
     "\n",
-    "codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-5ac8d4fa.csv\")\n",
+    "codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-0e6bb986.csv\")\n",
+    "codes_to_query_caseness = pandas.DataFrame(\n",
+    "    list(\n",
+    "        set(codes_to_query_caseness[\"code\"]).difference(\n",
+    "            set(codes_to_query_bipolar[\"code\"]).union(\n",
+    "                set(codes_to_query_schizophrenia[\"code\"])\n",
+    "            )\n",
+    "        )\n",
+    "    )\n",
+    "    ,columns = [\"code\"]\n",
+    ")\n",
     "\n",
     "codes_to_query_borderline = pandas.read_csv(folder + \"ciaranmci-borderline-personality-disorder-1ed4af38.csv\")\n",
     "codes_to_query_chronicDepression = pandas.read_csv(folder + \"ciaranmci-chronic-depression-53a65598.csv\")\n",
     "codes_to_query_chronicPTSD = pandas.read_csv(folder + \"ciaranmci-chronic-post-traumatic-stress-disorder-3a96e263.csv\")\n",
     "codes_to_query_complexPTSD = pandas.read_csv(folder + \"ciaranmci-complex-post-traumatic-stress-disorder-21876f2e.csv\")\n",
+    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
     "codes_to_query_dysthymia = pandas.read_csv(folder + \"ciaranmci-dysthymia-6f6888c3.csv\")\n",
-    "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-243a2f24.csv\")\n",
+    "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-5c4cd31b.csv\")\n",
     "\n",
     "# Medications of interest.\n",
     "medications_to_query_psychosisAndRelated = pandas.read_csv(folder + \"UNSEEN_medications_psychosisAndRelated.csv\")\n",
@@ -164,7 +162,7 @@
     "\n",
     "I first specify the population of interest with `person_id` values. These `person_id` values are filtered as follows:\n",
     "1. all people with a `person_id` in Connected Bradford's primary-care table,\n",
-    "2. aged between 18 and 70, inclusive, as of today's date (note: today's date is used rather than the `myIndexDate` date because this filter is for ethical research rather),\n",
+    "2. aged between 18 and 70, inclusive, as of today's date (note: today's date is used rather than the `myIndexDate` date),\n",
     "3. who have been registered with their practice for at least `min_GP_registeration_duration` years,\n",
     "4. who have a record of a SNOMED-CT diagnostic code from `codes_to_query_mentalIllHealth` within `Dx_windows` years prior to the `myIndexDate` date, or who have a record of prescriptions for medicines from `medications_to_query_all` within `Rx_windows` years prior to the `myIndexDate` date,\n",
     "5. excluding those people who have a record of a SNOMED-CT diagnostic code from `codes_to_query_schizophrenia` or `codes_to_query_bipolar`.\n",
@@ -174,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 28,
    "id": "bc365b3f-cca3-481b-b173-c2aceef40979",
    "metadata": {
     "jupyter": {
@@ -327,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 30,
    "id": "2c383190-8162-4a7c-8999-24f53f227412",
    "metadata": {
     "jupyter": {
@@ -371,7 +369,7 @@
     ")\n",
     ",tbl_persons_with_caseness_codes_and_medications AS (\n",
     "    SELECT\n",
-    "        tbl_persons_with_caseness_codes.person_id\n",
+    "        DISTINCT tbl_persons_with_caseness_codes.person_id\n",
     "        ,1 AS caseness_1isYes\n",
     "    FROM\n",
     "        tbl_persons_with_caseness_codes\n",
@@ -381,7 +379,7 @@
     ")\n",
     ",tbl_studyPopulation AS (\n",
     "    SELECT\n",
-    "        tbl_studyPopulation_no_caseness.person_id\n",
+    "        DISTINCT tbl_studyPopulation_no_caseness.person_id\n",
     "        ,CASE WHEN caseness_1isYes IS NULL THEN 0 ELSE 1 END AS caseness_1isYes\n",
     "    FROM\n",
     "        tbl_studyPopulation_no_caseness\n",
@@ -402,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 32,
    "id": "d75ca821-6440-44e1-b56f-a85ed244b659",
    "metadata": {
     "jupyter": {
@@ -412,18 +410,10 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.7/site-packages/google/auth/_default.py:78: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
-      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The prevalence of caseness among those with mental ill-health in the Connected Bradford dataset is \u001b[1m3.8%\u001b[0m. \n",
+      "The prevalence of caseness among those with mental ill-health in the Connected Bradford dataset is \u001b[1m2.4%\u001b[0m. \n",
       "\n",
       "Stored 'sql_declarations' (str)\n",
       "Stored 'sql_studyPopulation' (str)\n",
@@ -475,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 33,
    "id": "1461cc80-5008-4c77-a517-7b2d55171fa9",
    "metadata": {
     "jupyter": {
@@ -490,8 +480,8 @@
      "text": [
       "\n",
       " Calculating the entropy of the caseness variable in nats...\n",
-      "\t Caseness variable entropy = 0.161 nats\n",
-      "\t The caseness variable's entropy is 23.3 % of its theoretical maximum\n",
+      "\t Caseness variable entropy = 0.114 nats\n",
+      "\t The caseness variable's entropy is 16.4 % of its theoretical maximum\n",
       "\n"
      ]
     }
@@ -513,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 34,
    "id": "26f39a30-0d49-4a50-9979-1061f88568be",
    "metadata": {
     "jupyter": {
@@ -528,9 +518,9 @@
      "text": [
       "\n",
       " Calculating the hit rates of the caseness variable in nats...\n",
-      "\t Hit rate (all) = 3.79 %\n",
-      "\t Hit rate (none) = 96.21 %\n",
-      "\t Odds (No : Yes) = 25-times less likely to demonstrate caseness than to not.\n"
+      "\t Hit rate (all) = 2.416 %\n",
+      "\t Hit rate (none) = 97.584 %\n",
+      "\t Odds (No : Yes) = 40-times less likely to demonstrate caseness than to not.\n"
      ]
     }
    ],
@@ -549,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 35,
    "id": "93514baa-1ae5-4a42-a8db-40b1d03d44b1",
    "metadata": {
     "jupyter": {
@@ -563,15 +553,15 @@
       "text/markdown": [
        "    \n",
        "We now know that:\n",
-       "1. based on the scaled entropy, our variable indicating the caseness of complex mental health difficulties is $\\le23.3\\%$ as uncertain/surprising/unforeseeable\n",
+       "1. based on the scaled entropy, our variable indicating the caseness of complex mental health difficulties is $\\le16.4\\%$ as uncertain/surprising/unforeseeable\n",
        "as it could possibly be; _and_\n",
        "\n",
-       "2. we would correctly classify $\\ge96.2\\%$ of patients in this sample if we simply assumed that no one has complex mental health difficulties.\n",
+       "2. we would correctly classify $\\ge97.6\\%$ of patients in this sample if we simply assumed that no one has complex mental health difficulties.\n",
        "\n",
        "The first point tells us that definite caseness of complex mental health difficulties can be known with considerable certainty, in this dataset. There is only so much room for improvement via feature sets.\n",
        "\n",
        "The second point defines a benchmark for the indicative performance of any feature set that we evaluate in our study. Specifically, any feature set that we suggest to improve our certainty of knowing\n",
-       "that someone has complex mental health difficulties must correctly identify $\\ge96.2\\%$ of patients in our sample. Otherwise, the added feature set is a needless\n",
+       "that someone has complex mental health difficulties must correctly identify $\\ge97.6\\%$ of patients in our sample. Otherwise, the added feature set is a needless\n",
        "complication to our attempt to know whether or not someone has complex mental health difficulties (which we can often safely assume they don't). This is such a high benchmark that we will be very\n",
        "unlikely to find such a feature set.\n",
        "\n",
@@ -614,7 +604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 36,
    "id": "e6d784e3-f641-425c-84f5-fb0e596d6f66",
    "metadata": {
     "jupyter": {
@@ -632,10 +622,10 @@
        "| Statistic                      |    Value   |\n",
        "| ------------------------------ | -----------|\n",
        "| Normalised mutual information  | x → 0 |\n",
-       "| Class balance accuracy         | 0.48      |\n",
+       "| Class balance accuracy         | 0.49      |\n",
        "| Odds ratio                     | Not a number because one of the odds is zero.       |\n",
        "| Positive predictive value      | 0      |\n",
-       "| Negative predictive value      | 0.96      |\n",
+       "| Negative predictive value      | 0.98      |\n",
        "\n"
       ],
       "text/plain": [


### PR DESCRIPTION
By doing the breakdown of the caseness components, I discovered that I needed to do another round of excluding the schizophrenia and bipolar codes. The breakdown and the main caseness notebooks now match for the overall prevalence of caseness.