### PR TITLE
Remove Developmental Academic Disorder from caseness definition

### DIFF
--- a/.ipynb_checkpoints/UNSEEN_caseness_cohort_breakdown-checkpoint.ipynb
+++ b/.ipynb_checkpoints/UNSEEN_caseness_cohort_breakdown-checkpoint.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 1,
    "id": "41d1afc3-c12f-42fa-b9cb-3ed36514a7fa",
    "metadata": {
     "jupyter": {
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 2,
    "id": "a1386d0b-56fe-4684-b6f1-ef6e9bab36d3",
    "metadata": {
     "jupyter": {
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 3,
    "id": "d1bf06a3-ba12-422a-8350-b6b7048565e1",
    "metadata": {
     "jupyter": {
@@ -113,6 +113,7 @@
     "codes_to_query_mentalIllHealth = pandas.read_csv(folder + \"mental_ill_health_codelist.txt\", sep = '\\t')\n",
     "codes_to_query_bipolar = pandas.read_csv(folder + \"ciaranmci-bipolar-disorder-6a0308d7.csv\")\n",
     "codes_to_query_schizophrenia = pandas.read_csv(folder + \"ciaranmci-schizophrenia-05c53c03.csv\")\n",
+    "# ## Exclude bipolar and schizophrenia from the study population.\n",
     "codes_to_query_mentalIllHealth = pandas.DataFrame(\n",
     "    list(\n",
     "        set(codes_to_query_mentalIllHealth[\"Id\"]).difference(\n",
@@ -124,13 +125,20 @@
     "    ,columns = [\"Id\"]\n",
     ")\n",
     "\n",
+    "## ## Create codelist for the cases.\n",
     "#codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-0e6bb986.csv\")\n",
-    "\n",
+    "#codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
+    "## ## Exclude Developmental Academic Disorder from the cases.\n",
+    "#codes_to_query_caseness = pandas.DataFrame(\n",
+    "#   list(\n",
+    "#        set(codes_to_query_caseness[\"code\"]).difference( set(codes_to_query_devAcademicDisorder[\"code\"]) )\n",
+    "#        )\n",
+    "#    ,columns = [\"code\"]\n",
+    "#)\n",
     "codes_to_query_borderline = pandas.read_csv(folder + \"ciaranmci-borderline-personality-disorder-1ed4af38.csv\")\n",
     "codes_to_query_chronicDepression = pandas.read_csv(folder + \"ciaranmci-chronic-depression-53a65598.csv\")\n",
     "codes_to_query_chronicPTSD = pandas.read_csv(folder + \"ciaranmci-chronic-post-traumatic-stress-disorder-3a96e263.csv\")\n",
     "codes_to_query_complexPTSD = pandas.read_csv(folder + \"ciaranmci-complex-post-traumatic-stress-disorder-21876f2e.csv\")\n",
-    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
     "codes_to_query_dysthymia = pandas.read_csv(folder + \"ciaranmci-dysthymia-6f6888c3.csv\")\n",
     "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-5c4cd31b.csv\")\n",
     "\n",
@@ -144,7 +152,9 @@
   {
    "cell_type": "markdown",
    "id": "8e6500cc-06fb-416a-a410-ff306192723f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The script below is an edited version of the main script in `UNSESSN_create_caseness_variables.ipynb`. The main edit is that the `tbl_persons_with_caseness_codes` CTE is replaced by similar CTEs for each of the component diagnoses. I also replace `tbl_persons_with_medications` with similar CTEs for each of the component medications.\n",
     "\n",
@@ -153,14 +163,13 @@
     "2. Chronic depression\n",
     "3. Chronic posttraumatic stress disorder\n",
     "4. Complex posttraumatic stress disorder\n",
-    "5. Developmental academic disorder\n",
-    "6. Dysthymia\n",
-    "7. Personality disorder\n",
+    "5. Dysthymia\n",
+    "6. Personality disorder\n",
     "\n",
     "The list of component medications are:\n",
     "1. Antidepressants\n",
     "2. Hypnotics and anxiolytics\n",
-    "3. Medications associated with psychois and related disorders"
+    "3. Medications associated with psychosis and related disorders"
    ]
   },
   {
@@ -173,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 4,
    "id": "94fd978d-a789-496b-8b94-9524bcf7398c",
    "metadata": {
     "jupyter": {
@@ -215,14 +224,6 @@
     "    FROM\n",
     "        UNNEST([\n",
     "                '\"\"\" + '\\', \\''.join(map(str, codes_to_query_complexPTSD[\"code\"].tolist())) + \"\"\"'\n",
-    "                ]) AS my_snomedcode\n",
-    ")\n",
-    ",tbl_codes_devAcademicDisorder AS (\n",
-    "    SELECT\n",
-    "        my_snomedcode\n",
-    "    FROM\n",
-    "        UNNEST([\n",
-    "                '\"\"\" + '\\', \\''.join(map(str, codes_to_query_devAcademicDisorder[\"code\"].tolist())) + \"\"\"'\n",
     "                ]) AS my_snomedcode\n",
     ")\n",
     ",tbl_codes_dysthymia AS (\n",
@@ -358,28 +359,6 @@
     "        # This filters for diagnoses prior to the index date.\n",
     "        tbl_srcode.dateevent < myIndexDate\n",
     ")\n",
-    ",tbl_persons_with_devAcademicDisorder_codes AS (\n",
-    "    SELECT\n",
-    "        DISTINCT tbl_persons_firstFilters.person_id\n",
-    "        ,1 AS devAcademicDisorder\n",
-    "    FROM\n",
-    "        tbl_persons_firstFilters\n",
-    "    # This join gets the diagnostic SNOMED-CT codes, and filters for \n",
-    "    # the patients for which we have diagnostic codes because it is an\n",
-    "    # INNER JOIN.\n",
-    "    JOIN\n",
-    "        \"\"\" + server_id + \"\"\".\"\"\" + database_id + \"\"\".tbl_srcode\n",
-    "        ON tbl_persons_firstFilters.person_id = tbl_srcode.person_id\n",
-    "    # This join is filtering for patients with the diagnostic SNOMED-CT codes\n",
-    "    # of interest by using an INNER JOIN, which acts like an intersection in\n",
-    "    # set operations.\n",
-    "    JOIN \n",
-    "        tbl_codes_devAcademicDisorder\n",
-    "        ON tbl_srcode.snomedcode = tbl_codes_devAcademicDisorder.my_snomedcode\n",
-    "    WHERE\n",
-    "        # This filters for diagnoses prior to the index date.\n",
-    "        tbl_srcode.dateevent < myIndexDate\n",
-    ")\n",
     ",tbl_persons_with_dysthymia_codes AS (\n",
     "    SELECT\n",
     "        DISTINCT tbl_persons_firstFilters.person_id\n",
@@ -506,7 +485,6 @@
     "        ,CASE WHEN chronicDepression IS NULL THEN 0 ELSE 1 END AS chronicDepression\n",
     "        ,CASE WHEN chronicPTSD IS NULL THEN 0 ELSE 1 END AS chronicPTSD\n",
     "        ,CASE WHEN complexPTSD IS NULL THEN 0 ELSE 1 END AS complexPTSD\n",
-    "        ,CASE WHEN devAcademicDisorder IS NULL THEN 0 ELSE 1 END AS devAcademicDisorder\n",
     "        ,CASE WHEN dysthymia IS NULL THEN 0 ELSE 1 END AS dysthymia\n",
     "        ,CASE WHEN personalityDisorder IS NULL THEN 0 ELSE 1 END AS personalityDisorder\n",
     "        \n",
@@ -519,7 +497,6 @@
     "    LEFT JOIN tbl_persons_with_chronicDepression_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_chronicDepression_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_chronicPTSD_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_chronicPTSD_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_complexPTSD_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_complexPTSD_codes.person_id\n",
-    "    LEFT JOIN tbl_persons_with_devAcademicDisorder_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_devAcademicDisorder_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_dysthymia_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_dysthymia_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_personalityDisorder_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_personalityDisorder_codes.person_id\n",
     "    \n",
@@ -540,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 10,
    "id": "695bdb56-b89d-45f7-8de0-eb73e80d9614",
    "metadata": {
     "jupyter": {
@@ -567,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
+   "execution_count": 34,
    "id": "8c74d776-95f7-43e4-b881-8cba268710a5",
    "metadata": {
     "jupyter": {
@@ -580,7 +557,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1mNOTE: The overall proportion of patients satisfying caseness is 2.4%\u001b[0m\n"
+      "\u001b[1mNOTE: The overall proportion of patients satisfying caseness is 2.0%\u001b[0m\n"
      ]
     },
     {
@@ -635,12 +612,6 @@
        "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>devAcademicDisorder</th>\n",
-       "      <td>1790.0</td>\n",
-       "      <td>0.86</td>\n",
-       "      <td>8.61</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>dysthymia</th>\n",
        "      <td>520.0</td>\n",
        "      <td>0.25</td>\n",
@@ -680,7 +651,6 @@
        "chronicDepression          1180.0        0.57                     5.67\n",
        "chronicPTSD                 120.0        0.06                     0.58\n",
        "complexPTSD                   0.0        0.00                     0.00\n",
-       "devAcademicDisorder        1790.0        0.86                     8.61\n",
        "dysthymia                   520.0        0.25                     2.50\n",
        "personalityDisorder        3650.0        1.75                    17.55\n",
        "antidepressants          130520.0       62.75                   627.47\n",
@@ -693,12 +663,40 @@
     }
    ],
    "source": [
-    "counts_components = round(caseness_breakdown_array.iloc[:,1:].sum() / target_round) * target_round\n",
+    "counts_components = round(caseness_breakdown_array.iloc[:, ~caseness_breakdown_array.columns.isin(['person_id', 'count_of_diagnoses', 'count_of_medications'])].sum() / target_round) * target_round\n",
     "proportion = round((counts_components / count_studyPopulation) * 100, 2 )\n",
     "prevalence_per_thousand = round((counts_components / count_studyPopulation) * 1000, 2 )\n",
     "\n",
-    "print(f'\\033[1mNOTE: The overall proportion of patients satisfying caseness is {round((round(len(caseness_breakdown_array.loc[(count_of_diagnoses > 0) & (count_of_medications > 0),:]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
-    "\n",
+    "caseness_breakdown_array['count_of_diagnoses'] = \\\n",
+    "    pandas.DataFrame( caseness_breakdown_array.loc[:,\n",
+    "                                                   ~caseness_breakdown_array.columns.isin(['person_id', 'antidepressants', 'hypnoticsAndAnxiolytics',\n",
+    "                                                                                           'psychosisAndRelated', 'count_of_diagnoses', 'count_of_medications'])\n",
+    "                                                  ].sum(axis = 1), columns = ['count_of_diagnoses'] )\n",
+    "caseness_breakdown_array['count_of_medications'] = \\\n",
+    "    pandas.DataFrame( caseness_breakdown_array.loc[:,\n",
+    "                                                   ['antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated']\n",
+    "                                                  ].sum(axis = 1), columns = ['count_of_medications'] )\n",
+    "overall_proportion_satisfying_caseness = \\\n",
+    "    round(\n",
+    "        (\n",
+    "            round(\n",
+    "                len(\n",
+    "                    caseness_breakdown_array.loc[\n",
+    "                        (caseness_breakdown_array.count_of_diagnoses > 0) &\n",
+    "                        (caseness_breakdown_array.count_of_medications > 0)\n",
+    "                        ,:]\n",
+    "                ) / target_round\n",
+    "            ) * target_round\n",
+    "        ) / count_studyPopulation * 100\n",
+    "    , 1)\n",
+    "print(f'\\033[1mNOTE: The overall proportion of patients satisfying caseness is {overall_proportion_satisfying_caseness}%\\033[0m')\n",
+    "    \n",
+    "# n_hypnoticsAndAnxiolytics = 130\n",
+    "# n_antidepressants         = 1410\n",
+    "# n_psychosisAndRelated     = 120\n",
+    "# n_any                     = 4060\n",
+    "    \n",
+    "    \n",
     "display( pandas.DataFrame(data = {'counts' : counts_components, 'proportion' : proportion, 'prevalence_per_thousand' : prevalence_per_thousand} ) )"
    ]
   },
@@ -712,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 35,
    "id": "4d346a7b-3f7d-41ef-aa52-784cff67c938",
    "metadata": {
     "jupyter": {
@@ -725,7 +723,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1mNOTE: The proportion of patients with at least one diagnosis is 3.35%\u001b[0m\n"
+      "\u001b[1mNOTE: The proportion of patients with at least one diagnosis is 2.5%\u001b[0m\n"
      ]
     },
     {
@@ -756,23 +754,23 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0.0</th>\n",
-       "      <td>201050.0</td>\n",
-       "      <td>96.65</td>\n",
+       "      <td>202720.0</td>\n",
+       "      <td>97.46</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1.0</th>\n",
-       "      <td>6220.0</td>\n",
-       "      <td>2.99</td>\n",
+       "      <td>4660.0</td>\n",
+       "      <td>2.24</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2.0</th>\n",
-       "      <td>680.0</td>\n",
-       "      <td>0.33</td>\n",
+       "      <td>590.0</td>\n",
+       "      <td>0.28</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3.0</th>\n",
-       "      <td>60.0</td>\n",
-       "      <td>0.03</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>0.02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4.0</th>\n",
@@ -785,17 +783,17 @@
       ],
       "text/plain": [
        "     count_with_each_count_of_diagnoses  \\\n",
-       "0.0                            201050.0   \n",
-       "1.0                              6220.0   \n",
-       "2.0                               680.0   \n",
-       "3.0                                60.0   \n",
+       "0.0                            202720.0   \n",
+       "1.0                              4660.0   \n",
+       "2.0                               590.0   \n",
+       "3.0                                40.0   \n",
        "4.0                                 0.0   \n",
        "\n",
        "     proportion_with_each_count_of_diagnoses  \n",
-       "0.0                                    96.65  \n",
-       "1.0                                     2.99  \n",
-       "2.0                                     0.33  \n",
-       "3.0                                     0.03  \n",
+       "0.0                                    97.46  \n",
+       "1.0                                     2.24  \n",
+       "2.0                                     0.28  \n",
+       "3.0                                     0.02  \n",
        "4.0                                     0.00  "
       ]
      },
@@ -804,10 +802,19 @@
     }
    ],
    "source": [
-    "caseness_breakdown_array['count_of_diagnoses'] = pandas.DataFrame( caseness_breakdown_array.loc[:, ~caseness_breakdown_array.columns.isin(['person_id', 'antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated'])].sum(axis = 1), columns = ['count_of_diagnoses'] )\n",
-    "caseness_breakdown_array['count_of_medications'] = pandas.DataFrame( caseness_breakdown_array.loc[:,['antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated']].sum(axis = 1), columns = ['count_of_medications'] )\n",
-    "\n",
-    "print(f'\\033[1mNOTE: The proportion of patients with at least one diagnosis is {round((round(len(caseness_breakdown_array.loc[(count_of_diagnoses > 0)]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "proportion_with_at_least_one_diagnosis = \\\n",
+    "    round(\n",
+    "        (\n",
+    "            round(\n",
+    "                len(\n",
+    "                    caseness_breakdown_array.loc[\n",
+    "                        (caseness_breakdown_array.count_of_diagnoses > 0)\n",
+    "                    ]\n",
+    "                ) / target_round\n",
+    "            ) * target_round\n",
+    "        ) / count_studyPopulation * 100\n",
+    "    , 1)\n",
+    "print(f'\\033[1mNOTE: The proportion of patients with at least one diagnosis is {proportion_with_at_least_one_diagnosis}%\\033[0m')\n",
     "\n",
     "display(\n",
     "    pandas.DataFrame(\n",
@@ -829,7 +836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": 36,
    "id": "dea9fb1d-1757-4e69-8f8a-32038fa42ce2",
    "metadata": {
     "jupyter": {
@@ -842,7 +849,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1mNOTE: The proportion of patients with at least one medication is 73.07%\u001b[0m\n"
+      "\u001b[1mNOTE: The proportion of patients with at least one diagnosis is 73.1%\u001b[0m\n"
      ]
     },
     {
@@ -914,7 +921,20 @@
     }
    ],
    "source": [
-    "print(f'\\033[1mNOTE: The proportion of patients with at least one medication is {round((round(len(caseness_breakdown_array.loc[(count_of_medications > 0)]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "proportion_with_at_least_one_medication = \\\n",
+    "    round(\n",
+    "        (\n",
+    "            round(\n",
+    "                len(\n",
+    "                    caseness_breakdown_array.loc[\n",
+    "                        (caseness_breakdown_array.count_of_medications > 0)\n",
+    "                    ]\n",
+    "                ) / target_round\n",
+    "            ) * target_round\n",
+    "        ) / count_studyPopulation * 100\n",
+    "    , 1)\n",
+    "print(f'\\033[1mNOTE: The proportion of patients with at least one diagnosis is {proportion_with_at_least_one_medication}%\\033[0m')\n",
+    "\n",
     "display(\n",
     "    pandas.DataFrame(\n",
     "        data = {\n",

--- a/.ipynb_checkpoints/UNSEEN_create_caseness_variables-checkpoint.ipynb
+++ b/.ipynb_checkpoints/UNSEEN_create_caseness_variables-checkpoint.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 36,
    "id": "b476962c-70f3-413c-905e-b784dcc9bb93",
    "metadata": {
     "jupyter": {
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 37,
    "id": "089b7cb6-957f-4845-8f26-6f1d446a8912",
    "metadata": {
     "jupyter": {
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 46,
    "id": "3fc23759-0e6c-4fe4-9d1c-008db17a1825",
    "metadata": {
     "jupyter": {
@@ -115,6 +115,7 @@
     "codes_to_query_mentalIllHealth = pandas.read_csv(folder + \"mental_ill_health_codelist.txt\", sep = '\\t')\n",
     "codes_to_query_bipolar = pandas.read_csv(folder + \"ciaranmci-bipolar-disorder-6a0308d7.csv\")\n",
     "codes_to_query_schizophrenia = pandas.read_csv(folder + \"ciaranmci-schizophrenia-05c53c03.csv\")\n",
+    "# ## Exclude bipolar and schizophrenia from the study population.\n",
     "codes_to_query_mentalIllHealth = pandas.DataFrame(\n",
     "    list(\n",
     "        set(codes_to_query_mentalIllHealth[\"Id\"]).difference(\n",
@@ -126,23 +127,26 @@
     "    ,columns = [\"Id\"]\n",
     ")\n",
     "\n",
+    "# ## Create codelist for the cases.\n",
     "codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-0e6bb986.csv\")\n",
+    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
+    "# ## Exclude Developmental Academic Disorder from the cases.\n",
     "codes_to_query_caseness = pandas.DataFrame(\n",
     "    list(\n",
     "        set(codes_to_query_caseness[\"code\"]).difference(\n",
     "            set(codes_to_query_bipolar[\"code\"]).union(\n",
     "                set(codes_to_query_schizophrenia[\"code\"])\n",
+    "            ).union(\n",
+    "                set(codes_to_query_devAcademicDisorder[\"code\"])\n",
     "            )\n",
     "        )\n",
     "    )\n",
     "    ,columns = [\"code\"]\n",
     ")\n",
-    "\n",
     "codes_to_query_borderline = pandas.read_csv(folder + \"ciaranmci-borderline-personality-disorder-1ed4af38.csv\")\n",
     "codes_to_query_chronicDepression = pandas.read_csv(folder + \"ciaranmci-chronic-depression-53a65598.csv\")\n",
     "codes_to_query_chronicPTSD = pandas.read_csv(folder + \"ciaranmci-chronic-post-traumatic-stress-disorder-3a96e263.csv\")\n",
     "codes_to_query_complexPTSD = pandas.read_csv(folder + \"ciaranmci-complex-post-traumatic-stress-disorder-21876f2e.csv\")\n",
-    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
     "codes_to_query_dysthymia = pandas.read_csv(folder + \"ciaranmci-dysthymia-6f6888c3.csv\")\n",
     "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-5c4cd31b.csv\")\n",
     "\n",
@@ -172,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 39,
    "id": "bc365b3f-cca3-481b-b173-c2aceef40979",
    "metadata": {
     "jupyter": {
@@ -325,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 40,
    "id": "2c383190-8162-4a7c-8999-24f53f227412",
    "metadata": {
     "jupyter": {
@@ -400,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 41,
    "id": "d75ca821-6440-44e1-b56f-a85ed244b659",
    "metadata": {
     "jupyter": {
@@ -413,7 +417,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The prevalence of caseness among those with mental ill-health in the Connected Bradford dataset is \u001b[1m2.4%\u001b[0m. \n",
+      "The prevalence of caseness among those with mental ill-health in the Connected Bradford dataset is \u001b[1m2.0%\u001b[0m. \n",
       "\n",
       "Stored 'sql_declarations' (str)\n",
       "Stored 'sql_studyPopulation' (str)\n",
@@ -465,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 42,
    "id": "1461cc80-5008-4c77-a517-7b2d55171fa9",
    "metadata": {
     "jupyter": {
@@ -480,8 +484,8 @@
      "text": [
       "\n",
       " Calculating the entropy of the caseness variable in nats...\n",
-      "\t Caseness variable entropy = 0.114 nats\n",
-      "\t The caseness variable's entropy is 16.4 % of its theoretical maximum\n",
+      "\t Caseness variable entropy = 0.097 nats\n",
+      "\t The caseness variable's entropy is 14.0 % of its theoretical maximum\n",
       "\n"
      ]
     }
@@ -503,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 43,
    "id": "26f39a30-0d49-4a50-9979-1061f88568be",
    "metadata": {
     "jupyter": {
@@ -518,9 +522,9 @@
      "text": [
       "\n",
       " Calculating the hit rates of the caseness variable in nats...\n",
-      "\t Hit rate (all) = 2.416 %\n",
-      "\t Hit rate (none) = 97.584 %\n",
-      "\t Odds (No : Yes) = 40-times less likely to demonstrate caseness than to not.\n"
+      "\t Hit rate (all) = 1.969 %\n",
+      "\t Hit rate (none) = 98.031 %\n",
+      "\t Odds (No : Yes) = 49-times less likely to demonstrate caseness than to not.\n"
      ]
     }
    ],
@@ -539,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 44,
    "id": "93514baa-1ae5-4a42-a8db-40b1d03d44b1",
    "metadata": {
     "jupyter": {
@@ -553,15 +557,15 @@
       "text/markdown": [
        "    \n",
        "We now know that:\n",
-       "1. based on the scaled entropy, our variable indicating the caseness of complex mental health difficulties is $\\le16.4\\%$ as uncertain/surprising/unforeseeable\n",
+       "1. based on the scaled entropy, our variable indicating the caseness of complex mental health difficulties is $\\le14.0\\%$ as uncertain/surprising/unforeseeable\n",
        "as it could possibly be; _and_\n",
        "\n",
-       "2. we would correctly classify $\\ge97.6\\%$ of patients in this sample if we simply assumed that no one has complex mental health difficulties.\n",
+       "2. we would correctly classify $\\ge98.0\\%$ of patients in this sample if we simply assumed that no one has complex mental health difficulties.\n",
        "\n",
        "The first point tells us that definite caseness of complex mental health difficulties can be known with considerable certainty, in this dataset. There is only so much room for improvement via feature sets.\n",
        "\n",
        "The second point defines a benchmark for the indicative performance of any feature set that we evaluate in our study. Specifically, any feature set that we suggest to improve our certainty of knowing\n",
-       "that someone has complex mental health difficulties must correctly identify $\\ge97.6\\%$ of patients in our sample. Otherwise, the added feature set is a needless\n",
+       "that someone has complex mental health difficulties must correctly identify $\\ge98.0\\%$ of patients in our sample. Otherwise, the added feature set is a needless\n",
        "complication to our attempt to know whether or not someone has complex mental health difficulties (which we can often safely assume they don't). This is such a high benchmark that we will be very\n",
        "unlikely to find such a feature set.\n",
        "\n",
@@ -604,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 45,
    "id": "e6d784e3-f641-425c-84f5-fb0e596d6f66",
    "metadata": {
     "jupyter": {

--- a/UNSEEN_caseness_cohort_breakdown.ipynb
+++ b/UNSEEN_caseness_cohort_breakdown.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 1,
    "id": "41d1afc3-c12f-42fa-b9cb-3ed36514a7fa",
    "metadata": {
     "jupyter": {
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 2,
    "id": "a1386d0b-56fe-4684-b6f1-ef6e9bab36d3",
    "metadata": {
     "jupyter": {
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 3,
    "id": "d1bf06a3-ba12-422a-8350-b6b7048565e1",
    "metadata": {
     "jupyter": {
@@ -113,6 +113,7 @@
     "codes_to_query_mentalIllHealth = pandas.read_csv(folder + \"mental_ill_health_codelist.txt\", sep = '\\t')\n",
     "codes_to_query_bipolar = pandas.read_csv(folder + \"ciaranmci-bipolar-disorder-6a0308d7.csv\")\n",
     "codes_to_query_schizophrenia = pandas.read_csv(folder + \"ciaranmci-schizophrenia-05c53c03.csv\")\n",
+    "# ## Exclude bipolar and schizophrenia from the study population.\n",
     "codes_to_query_mentalIllHealth = pandas.DataFrame(\n",
     "    list(\n",
     "        set(codes_to_query_mentalIllHealth[\"Id\"]).difference(\n",
@@ -124,13 +125,20 @@
     "    ,columns = [\"Id\"]\n",
     ")\n",
     "\n",
+    "## ## Create codelist for the cases.\n",
     "#codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-0e6bb986.csv\")\n",
-    "\n",
+    "#codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
+    "## ## Exclude Developmental Academic Disorder from the cases.\n",
+    "#codes_to_query_caseness = pandas.DataFrame(\n",
+    "#   list(\n",
+    "#        set(codes_to_query_caseness[\"code\"]).difference( set(codes_to_query_devAcademicDisorder[\"code\"]) )\n",
+    "#        )\n",
+    "#    ,columns = [\"code\"]\n",
+    "#)\n",
     "codes_to_query_borderline = pandas.read_csv(folder + \"ciaranmci-borderline-personality-disorder-1ed4af38.csv\")\n",
     "codes_to_query_chronicDepression = pandas.read_csv(folder + \"ciaranmci-chronic-depression-53a65598.csv\")\n",
     "codes_to_query_chronicPTSD = pandas.read_csv(folder + \"ciaranmci-chronic-post-traumatic-stress-disorder-3a96e263.csv\")\n",
     "codes_to_query_complexPTSD = pandas.read_csv(folder + \"ciaranmci-complex-post-traumatic-stress-disorder-21876f2e.csv\")\n",
-    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
     "codes_to_query_dysthymia = pandas.read_csv(folder + \"ciaranmci-dysthymia-6f6888c3.csv\")\n",
     "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-5c4cd31b.csv\")\n",
     "\n",
@@ -144,7 +152,9 @@
   {
    "cell_type": "markdown",
    "id": "8e6500cc-06fb-416a-a410-ff306192723f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The script below is an edited version of the main script in `UNSESSN_create_caseness_variables.ipynb`. The main edit is that the `tbl_persons_with_caseness_codes` CTE is replaced by similar CTEs for each of the component diagnoses. I also replace `tbl_persons_with_medications` with similar CTEs for each of the component medications.\n",
     "\n",
@@ -153,14 +163,13 @@
     "2. Chronic depression\n",
     "3. Chronic posttraumatic stress disorder\n",
     "4. Complex posttraumatic stress disorder\n",
-    "5. Developmental academic disorder\n",
-    "6. Dysthymia\n",
-    "7. Personality disorder\n",
+    "5. Dysthymia\n",
+    "6. Personality disorder\n",
     "\n",
     "The list of component medications are:\n",
     "1. Antidepressants\n",
     "2. Hypnotics and anxiolytics\n",
-    "3. Medications associated with psychois and related disorders"
+    "3. Medications associated with psychosis and related disorders"
    ]
   },
   {
@@ -173,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 4,
    "id": "94fd978d-a789-496b-8b94-9524bcf7398c",
    "metadata": {
     "jupyter": {
@@ -215,14 +224,6 @@
     "    FROM\n",
     "        UNNEST([\n",
     "                '\"\"\" + '\\', \\''.join(map(str, codes_to_query_complexPTSD[\"code\"].tolist())) + \"\"\"'\n",
-    "                ]) AS my_snomedcode\n",
-    ")\n",
-    ",tbl_codes_devAcademicDisorder AS (\n",
-    "    SELECT\n",
-    "        my_snomedcode\n",
-    "    FROM\n",
-    "        UNNEST([\n",
-    "                '\"\"\" + '\\', \\''.join(map(str, codes_to_query_devAcademicDisorder[\"code\"].tolist())) + \"\"\"'\n",
     "                ]) AS my_snomedcode\n",
     ")\n",
     ",tbl_codes_dysthymia AS (\n",
@@ -358,28 +359,6 @@
     "        # This filters for diagnoses prior to the index date.\n",
     "        tbl_srcode.dateevent < myIndexDate\n",
     ")\n",
-    ",tbl_persons_with_devAcademicDisorder_codes AS (\n",
-    "    SELECT\n",
-    "        DISTINCT tbl_persons_firstFilters.person_id\n",
-    "        ,1 AS devAcademicDisorder\n",
-    "    FROM\n",
-    "        tbl_persons_firstFilters\n",
-    "    # This join gets the diagnostic SNOMED-CT codes, and filters for \n",
-    "    # the patients for which we have diagnostic codes because it is an\n",
-    "    # INNER JOIN.\n",
-    "    JOIN\n",
-    "        \"\"\" + server_id + \"\"\".\"\"\" + database_id + \"\"\".tbl_srcode\n",
-    "        ON tbl_persons_firstFilters.person_id = tbl_srcode.person_id\n",
-    "    # This join is filtering for patients with the diagnostic SNOMED-CT codes\n",
-    "    # of interest by using an INNER JOIN, which acts like an intersection in\n",
-    "    # set operations.\n",
-    "    JOIN \n",
-    "        tbl_codes_devAcademicDisorder\n",
-    "        ON tbl_srcode.snomedcode = tbl_codes_devAcademicDisorder.my_snomedcode\n",
-    "    WHERE\n",
-    "        # This filters for diagnoses prior to the index date.\n",
-    "        tbl_srcode.dateevent < myIndexDate\n",
-    ")\n",
     ",tbl_persons_with_dysthymia_codes AS (\n",
     "    SELECT\n",
     "        DISTINCT tbl_persons_firstFilters.person_id\n",
@@ -506,7 +485,6 @@
     "        ,CASE WHEN chronicDepression IS NULL THEN 0 ELSE 1 END AS chronicDepression\n",
     "        ,CASE WHEN chronicPTSD IS NULL THEN 0 ELSE 1 END AS chronicPTSD\n",
     "        ,CASE WHEN complexPTSD IS NULL THEN 0 ELSE 1 END AS complexPTSD\n",
-    "        ,CASE WHEN devAcademicDisorder IS NULL THEN 0 ELSE 1 END AS devAcademicDisorder\n",
     "        ,CASE WHEN dysthymia IS NULL THEN 0 ELSE 1 END AS dysthymia\n",
     "        ,CASE WHEN personalityDisorder IS NULL THEN 0 ELSE 1 END AS personalityDisorder\n",
     "        \n",
@@ -519,7 +497,6 @@
     "    LEFT JOIN tbl_persons_with_chronicDepression_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_chronicDepression_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_chronicPTSD_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_chronicPTSD_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_complexPTSD_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_complexPTSD_codes.person_id\n",
-    "    LEFT JOIN tbl_persons_with_devAcademicDisorder_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_devAcademicDisorder_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_dysthymia_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_dysthymia_codes.person_id\n",
     "    LEFT JOIN tbl_persons_with_personalityDisorder_codes ON tbl_studyPopulation_no_caseness.person_id = tbl_persons_with_personalityDisorder_codes.person_id\n",
     "    \n",
@@ -540,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 10,
    "id": "695bdb56-b89d-45f7-8de0-eb73e80d9614",
    "metadata": {
     "jupyter": {
@@ -567,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
+   "execution_count": 34,
    "id": "8c74d776-95f7-43e4-b881-8cba268710a5",
    "metadata": {
     "jupyter": {
@@ -580,7 +557,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1mNOTE: The overall proportion of patients satisfying caseness is 2.4%\u001b[0m\n"
+      "\u001b[1mNOTE: The overall proportion of patients satisfying caseness is 2.0%\u001b[0m\n"
      ]
     },
     {
@@ -635,12 +612,6 @@
        "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>devAcademicDisorder</th>\n",
-       "      <td>1790.0</td>\n",
-       "      <td>0.86</td>\n",
-       "      <td>8.61</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>dysthymia</th>\n",
        "      <td>520.0</td>\n",
        "      <td>0.25</td>\n",
@@ -680,7 +651,6 @@
        "chronicDepression          1180.0        0.57                     5.67\n",
        "chronicPTSD                 120.0        0.06                     0.58\n",
        "complexPTSD                   0.0        0.00                     0.00\n",
-       "devAcademicDisorder        1790.0        0.86                     8.61\n",
        "dysthymia                   520.0        0.25                     2.50\n",
        "personalityDisorder        3650.0        1.75                    17.55\n",
        "antidepressants          130520.0       62.75                   627.47\n",
@@ -693,12 +663,40 @@
     }
    ],
    "source": [
-    "counts_components = round(caseness_breakdown_array.iloc[:,1:].sum() / target_round) * target_round\n",
+    "counts_components = round(caseness_breakdown_array.iloc[:, ~caseness_breakdown_array.columns.isin(['person_id', 'count_of_diagnoses', 'count_of_medications'])].sum() / target_round) * target_round\n",
     "proportion = round((counts_components / count_studyPopulation) * 100, 2 )\n",
     "prevalence_per_thousand = round((counts_components / count_studyPopulation) * 1000, 2 )\n",
     "\n",
-    "print(f'\\033[1mNOTE: The overall proportion of patients satisfying caseness is {round((round(len(caseness_breakdown_array.loc[(count_of_diagnoses > 0) & (count_of_medications > 0),:]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
-    "\n",
+    "caseness_breakdown_array['count_of_diagnoses'] = \\\n",
+    "    pandas.DataFrame( caseness_breakdown_array.loc[:,\n",
+    "                                                   ~caseness_breakdown_array.columns.isin(['person_id', 'antidepressants', 'hypnoticsAndAnxiolytics',\n",
+    "                                                                                           'psychosisAndRelated', 'count_of_diagnoses', 'count_of_medications'])\n",
+    "                                                  ].sum(axis = 1), columns = ['count_of_diagnoses'] )\n",
+    "caseness_breakdown_array['count_of_medications'] = \\\n",
+    "    pandas.DataFrame( caseness_breakdown_array.loc[:,\n",
+    "                                                   ['antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated']\n",
+    "                                                  ].sum(axis = 1), columns = ['count_of_medications'] )\n",
+    "overall_proportion_satisfying_caseness = \\\n",
+    "    round(\n",
+    "        (\n",
+    "            round(\n",
+    "                len(\n",
+    "                    caseness_breakdown_array.loc[\n",
+    "                        (caseness_breakdown_array.count_of_diagnoses > 0) &\n",
+    "                        (caseness_breakdown_array.count_of_medications > 0)\n",
+    "                        ,:]\n",
+    "                ) / target_round\n",
+    "            ) * target_round\n",
+    "        ) / count_studyPopulation * 100\n",
+    "    , 1)\n",
+    "print(f'\\033[1mNOTE: The overall proportion of patients satisfying caseness is {overall_proportion_satisfying_caseness}%\\033[0m')\n",
+    "    \n",
+    "# n_hypnoticsAndAnxiolytics = 130\n",
+    "# n_antidepressants         = 1410\n",
+    "# n_psychosisAndRelated     = 120\n",
+    "# n_any                     = 4060\n",
+    "    \n",
+    "    \n",
     "display( pandas.DataFrame(data = {'counts' : counts_components, 'proportion' : proportion, 'prevalence_per_thousand' : prevalence_per_thousand} ) )"
    ]
   },
@@ -712,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 35,
    "id": "4d346a7b-3f7d-41ef-aa52-784cff67c938",
    "metadata": {
     "jupyter": {
@@ -725,7 +723,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1mNOTE: The proportion of patients with at least one diagnosis is 3.35%\u001b[0m\n"
+      "\u001b[1mNOTE: The proportion of patients with at least one diagnosis is 2.5%\u001b[0m\n"
      ]
     },
     {
@@ -756,23 +754,23 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0.0</th>\n",
-       "      <td>201050.0</td>\n",
-       "      <td>96.65</td>\n",
+       "      <td>202720.0</td>\n",
+       "      <td>97.46</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1.0</th>\n",
-       "      <td>6220.0</td>\n",
-       "      <td>2.99</td>\n",
+       "      <td>4660.0</td>\n",
+       "      <td>2.24</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2.0</th>\n",
-       "      <td>680.0</td>\n",
-       "      <td>0.33</td>\n",
+       "      <td>590.0</td>\n",
+       "      <td>0.28</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3.0</th>\n",
-       "      <td>60.0</td>\n",
-       "      <td>0.03</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>0.02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4.0</th>\n",
@@ -785,17 +783,17 @@
       ],
       "text/plain": [
        "     count_with_each_count_of_diagnoses  \\\n",
-       "0.0                            201050.0   \n",
-       "1.0                              6220.0   \n",
-       "2.0                               680.0   \n",
-       "3.0                                60.0   \n",
+       "0.0                            202720.0   \n",
+       "1.0                              4660.0   \n",
+       "2.0                               590.0   \n",
+       "3.0                                40.0   \n",
        "4.0                                 0.0   \n",
        "\n",
        "     proportion_with_each_count_of_diagnoses  \n",
-       "0.0                                    96.65  \n",
-       "1.0                                     2.99  \n",
-       "2.0                                     0.33  \n",
-       "3.0                                     0.03  \n",
+       "0.0                                    97.46  \n",
+       "1.0                                     2.24  \n",
+       "2.0                                     0.28  \n",
+       "3.0                                     0.02  \n",
        "4.0                                     0.00  "
       ]
      },
@@ -804,10 +802,19 @@
     }
    ],
    "source": [
-    "caseness_breakdown_array['count_of_diagnoses'] = pandas.DataFrame( caseness_breakdown_array.loc[:, ~caseness_breakdown_array.columns.isin(['person_id', 'antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated'])].sum(axis = 1), columns = ['count_of_diagnoses'] )\n",
-    "caseness_breakdown_array['count_of_medications'] = pandas.DataFrame( caseness_breakdown_array.loc[:,['antidepressants', 'hypnoticsAndAnxiolytics', 'psychosisAndRelated']].sum(axis = 1), columns = ['count_of_medications'] )\n",
-    "\n",
-    "print(f'\\033[1mNOTE: The proportion of patients with at least one diagnosis is {round((round(len(caseness_breakdown_array.loc[(count_of_diagnoses > 0)]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "proportion_with_at_least_one_diagnosis = \\\n",
+    "    round(\n",
+    "        (\n",
+    "            round(\n",
+    "                len(\n",
+    "                    caseness_breakdown_array.loc[\n",
+    "                        (caseness_breakdown_array.count_of_diagnoses > 0)\n",
+    "                    ]\n",
+    "                ) / target_round\n",
+    "            ) * target_round\n",
+    "        ) / count_studyPopulation * 100\n",
+    "    , 1)\n",
+    "print(f'\\033[1mNOTE: The proportion of patients with at least one diagnosis is {proportion_with_at_least_one_diagnosis}%\\033[0m')\n",
     "\n",
     "display(\n",
     "    pandas.DataFrame(\n",
@@ -829,7 +836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": 36,
    "id": "dea9fb1d-1757-4e69-8f8a-32038fa42ce2",
    "metadata": {
     "jupyter": {
@@ -842,7 +849,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1mNOTE: The proportion of patients with at least one medication is 73.07%\u001b[0m\n"
+      "\u001b[1mNOTE: The proportion of patients with at least one diagnosis is 73.1%\u001b[0m\n"
      ]
     },
     {
@@ -914,7 +921,20 @@
     }
    ],
    "source": [
-    "print(f'\\033[1mNOTE: The proportion of patients with at least one medication is {round((round(len(caseness_breakdown_array.loc[(count_of_medications > 0)]) / target_round) * target_round) / count_studyPopulation * 100, 2)}%\\033[0m')\n",
+    "proportion_with_at_least_one_medication = \\\n",
+    "    round(\n",
+    "        (\n",
+    "            round(\n",
+    "                len(\n",
+    "                    caseness_breakdown_array.loc[\n",
+    "                        (caseness_breakdown_array.count_of_medications > 0)\n",
+    "                    ]\n",
+    "                ) / target_round\n",
+    "            ) * target_round\n",
+    "        ) / count_studyPopulation * 100\n",
+    "    , 1)\n",
+    "print(f'\\033[1mNOTE: The proportion of patients with at least one diagnosis is {proportion_with_at_least_one_medication}%\\033[0m')\n",
+    "\n",
     "display(\n",
     "    pandas.DataFrame(\n",
     "        data = {\n",

--- a/UNSEEN_create_caseness_variables.ipynb
+++ b/UNSEEN_create_caseness_variables.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 36,
    "id": "b476962c-70f3-413c-905e-b784dcc9bb93",
    "metadata": {
     "jupyter": {
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 37,
    "id": "089b7cb6-957f-4845-8f26-6f1d446a8912",
    "metadata": {
     "jupyter": {
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 46,
    "id": "3fc23759-0e6c-4fe4-9d1c-008db17a1825",
    "metadata": {
     "jupyter": {
@@ -115,6 +115,7 @@
     "codes_to_query_mentalIllHealth = pandas.read_csv(folder + \"mental_ill_health_codelist.txt\", sep = '\\t')\n",
     "codes_to_query_bipolar = pandas.read_csv(folder + \"ciaranmci-bipolar-disorder-6a0308d7.csv\")\n",
     "codes_to_query_schizophrenia = pandas.read_csv(folder + \"ciaranmci-schizophrenia-05c53c03.csv\")\n",
+    "# ## Exclude bipolar and schizophrenia from the study population.\n",
     "codes_to_query_mentalIllHealth = pandas.DataFrame(\n",
     "    list(\n",
     "        set(codes_to_query_mentalIllHealth[\"Id\"]).difference(\n",
@@ -126,23 +127,26 @@
     "    ,columns = [\"Id\"]\n",
     ")\n",
     "\n",
+    "# ## Create codelist for the cases.\n",
     "codes_to_query_caseness = pandas.read_csv(folder + \"ciaranmci-unseen-snomed-codes-to-identify-cmhd-0e6bb986.csv\")\n",
+    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
+    "# ## Exclude Developmental Academic Disorder from the cases.\n",
     "codes_to_query_caseness = pandas.DataFrame(\n",
     "    list(\n",
     "        set(codes_to_query_caseness[\"code\"]).difference(\n",
     "            set(codes_to_query_bipolar[\"code\"]).union(\n",
     "                set(codes_to_query_schizophrenia[\"code\"])\n",
+    "            ).union(\n",
+    "                set(codes_to_query_devAcademicDisorder[\"code\"])\n",
     "            )\n",
     "        )\n",
     "    )\n",
     "    ,columns = [\"code\"]\n",
     ")\n",
-    "\n",
     "codes_to_query_borderline = pandas.read_csv(folder + \"ciaranmci-borderline-personality-disorder-1ed4af38.csv\")\n",
     "codes_to_query_chronicDepression = pandas.read_csv(folder + \"ciaranmci-chronic-depression-53a65598.csv\")\n",
     "codes_to_query_chronicPTSD = pandas.read_csv(folder + \"ciaranmci-chronic-post-traumatic-stress-disorder-3a96e263.csv\")\n",
     "codes_to_query_complexPTSD = pandas.read_csv(folder + \"ciaranmci-complex-post-traumatic-stress-disorder-21876f2e.csv\")\n",
-    "codes_to_query_devAcademicDisorder = pandas.read_csv(folder + \"ciaranmci-developmental-academic-disorder-755c4650.csv\")\n",
     "codes_to_query_dysthymia = pandas.read_csv(folder + \"ciaranmci-dysthymia-6f6888c3.csv\")\n",
     "codes_to_query_personalityDisorder = pandas.read_csv(folder + \"ciaranmci-personality-disorder-5c4cd31b.csv\")\n",
     "\n",
@@ -172,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 39,
    "id": "bc365b3f-cca3-481b-b173-c2aceef40979",
    "metadata": {
     "jupyter": {
@@ -325,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 40,
    "id": "2c383190-8162-4a7c-8999-24f53f227412",
    "metadata": {
     "jupyter": {
@@ -400,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 41,
    "id": "d75ca821-6440-44e1-b56f-a85ed244b659",
    "metadata": {
     "jupyter": {
@@ -413,7 +417,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The prevalence of caseness among those with mental ill-health in the Connected Bradford dataset is \u001b[1m2.4%\u001b[0m. \n",
+      "The prevalence of caseness among those with mental ill-health in the Connected Bradford dataset is \u001b[1m2.0%\u001b[0m. \n",
       "\n",
       "Stored 'sql_declarations' (str)\n",
       "Stored 'sql_studyPopulation' (str)\n",
@@ -465,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 42,
    "id": "1461cc80-5008-4c77-a517-7b2d55171fa9",
    "metadata": {
     "jupyter": {
@@ -480,8 +484,8 @@
      "text": [
       "\n",
       " Calculating the entropy of the caseness variable in nats...\n",
-      "\t Caseness variable entropy = 0.114 nats\n",
-      "\t The caseness variable's entropy is 16.4 % of its theoretical maximum\n",
+      "\t Caseness variable entropy = 0.097 nats\n",
+      "\t The caseness variable's entropy is 14.0 % of its theoretical maximum\n",
       "\n"
      ]
     }
@@ -503,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 43,
    "id": "26f39a30-0d49-4a50-9979-1061f88568be",
    "metadata": {
     "jupyter": {
@@ -518,9 +522,9 @@
      "text": [
       "\n",
       " Calculating the hit rates of the caseness variable in nats...\n",
-      "\t Hit rate (all) = 2.416 %\n",
-      "\t Hit rate (none) = 97.584 %\n",
-      "\t Odds (No : Yes) = 40-times less likely to demonstrate caseness than to not.\n"
+      "\t Hit rate (all) = 1.969 %\n",
+      "\t Hit rate (none) = 98.031 %\n",
+      "\t Odds (No : Yes) = 49-times less likely to demonstrate caseness than to not.\n"
      ]
     }
    ],
@@ -539,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 44,
    "id": "93514baa-1ae5-4a42-a8db-40b1d03d44b1",
    "metadata": {
     "jupyter": {
@@ -553,15 +557,15 @@
       "text/markdown": [
        "    \n",
        "We now know that:\n",
-       "1. based on the scaled entropy, our variable indicating the caseness of complex mental health difficulties is $\\le16.4\\%$ as uncertain/surprising/unforeseeable\n",
+       "1. based on the scaled entropy, our variable indicating the caseness of complex mental health difficulties is $\\le14.0\\%$ as uncertain/surprising/unforeseeable\n",
        "as it could possibly be; _and_\n",
        "\n",
-       "2. we would correctly classify $\\ge97.6\\%$ of patients in this sample if we simply assumed that no one has complex mental health difficulties.\n",
+       "2. we would correctly classify $\\ge98.0\\%$ of patients in this sample if we simply assumed that no one has complex mental health difficulties.\n",
        "\n",
        "The first point tells us that definite caseness of complex mental health difficulties can be known with considerable certainty, in this dataset. There is only so much room for improvement via feature sets.\n",
        "\n",
        "The second point defines a benchmark for the indicative performance of any feature set that we evaluate in our study. Specifically, any feature set that we suggest to improve our certainty of knowing\n",
-       "that someone has complex mental health difficulties must correctly identify $\\ge97.6\\%$ of patients in our sample. Otherwise, the added feature set is a needless\n",
+       "that someone has complex mental health difficulties must correctly identify $\\ge98.0\\%$ of patients in our sample. Otherwise, the added feature set is a needless\n",
        "complication to our attempt to know whether or not someone has complex mental health difficulties (which we can often safely assume they don't). This is such a high benchmark that we will be very\n",
        "unlikely to find such a feature set.\n",
        "\n",
@@ -604,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 45,
    "id": "e6d784e3-f641-425c-84f5-fb0e596d6f66",
    "metadata": {
     "jupyter": {


### PR DESCRIPTION
In a meeting between CMI and CB on 10th August 2023, CB decided that Developmental Academic Disorder should not be a criterion diagnosis for the caseness of complex mental health difficulties. In an email sent on the 9th August, CB said:

> "I don't think Developmental Academic Disorder should be in our caseness set.
I don't recall it as being in our conceptualisation (some neurodev disorders such as ASDs are in the complex feature sets but shouldn't be cases).
> What's more I  stumbled upon the term today in practice - it's not one I recognise from UK clinical practice or Read codes but it's essentially the root of learning disability (I did a LD review on someone and saw these SNOMED codes appearing!).   I have checked SNOMED CT and the hierarchy goes:
? Mental Disorders / Developmental Mental Disorders / Developmental Academic Disorders / {Learning disability etc.....}

> We shouldn't have DADs in the mix. I suspect that quite a lot of these will be in single-code "cases" so it will probably bring the caseness prevalence down quite a bit further.  "