### PR TITLE
Example kernel crash trigger

### DIFF
--- a/.ipynb_checkpoints/Example_kernel_crash_trigger-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Example_kernel_crash_trigger-checkpoint.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c5d5ebd7-9048-4da9-aabf-d2200f8ad870",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "active information value for the `working` list =       1.6472585776066269\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from ctypes import byref, c_int, c_ulong, c_double, POINTER\n",
+    "try:\n",
+    "    import pyinform\n",
+    "except:\n",
+    "    !pip install pyinform # Only include ! if using Jupyter notebook.\n",
+    "    import pyinform\n",
+    "    from pyinform.error import ErrorCode, error_guard\n",
+    "\n",
+    "working = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    " 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    " 0, 0, 0, 5, 9, 9, 9, 2, 10, 6, 6, 4, 4, 11, 1, 3, 3, 1, 5, 17, 3]\n",
+    "\n",
+    "\n",
+    "not_working = [0, 0, 0, 13, 10, 5, 6, 18, 8, 4, 2, 0, 3, 6, 27, 11, 0, 7, 5,\n",
+    " 4, 8, 14, 14, 11, 19, 49, 49, 49, 36, 25, 16, 37, 60, 71, 75, 39, 40, 22, 18,\n",
+    " 22, 27, 20, 19, 21, 19, 25, 38, 15, 22, 8, 10, 9, 9, 11, 8, 9, 13, 33, 47, 25,\n",
+    " 14, 10, 8, 4, 2, 13, 23, 25]\n",
+    "\n",
+    "\n",
+    "print(f'active information value for the `working` list = \\\n",
+    "      {pyinform.activeinfo.active_info(working, k = 4)}')\n",
+    "print(f'active information value for the `not_working` list = \\\n",
+    "      {pyinform.activeinfo.active_info(not_working, k = 4)}')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "r-cpu.4-2.m109",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m109"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Example_kernel_crash_trigger.ipynb
+++ b/Example_kernel_crash_trigger.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c5d5ebd7-9048-4da9-aabf-d2200f8ad870",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "active information value for the `working` list =       1.6472585776066269\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from ctypes import byref, c_int, c_ulong, c_double, POINTER\n",
+    "try:\n",
+    "    import pyinform\n",
+    "except:\n",
+    "    !pip install pyinform # Only include ! if using Jupyter notebook.\n",
+    "    import pyinform\n",
+    "    from pyinform.error import ErrorCode, error_guard\n",
+    "\n",
+    "working = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    " 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+    " 0, 0, 0, 5, 9, 9, 9, 2, 10, 6, 6, 4, 4, 11, 1, 3, 3, 1, 5, 17, 3]\n",
+    "\n",
+    "\n",
+    "not_working = [0, 0, 0, 13, 10, 5, 6, 18, 8, 4, 2, 0, 3, 6, 27, 11, 0, 7, 5,\n",
+    " 4, 8, 14, 14, 11, 19, 49, 49, 49, 36, 25, 16, 37, 60, 71, 75, 39, 40, 22, 18,\n",
+    " 22, 27, 20, 19, 21, 19, 25, 38, 15, 22, 8, 10, 9, 9, 11, 8, 9, 13, 33, 47, 25,\n",
+    " 14, 10, 8, 4, 2, 13, 23, 25]\n",
+    "\n",
+    "\n",
+    "print(f'active information value for the `working` list = \\\n",
+    "      {pyinform.activeinfo.active_info(working, k = 4)}')\n",
+    "print(f'active information value for the `not_working` list = \\\n",
+    "      {pyinform.activeinfo.active_info(not_working, k = 4)}')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "r-cpu.4-2.m109",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m109"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I've been having many issues with the python kernel dying. I've managed to find details of a particular case that triggers the python kernel to crash. This example is when I call the [pyinform.activeinfo.active_info()](https://elife-asu.github.io/PyInform/_modules/pyinform/activeinfo.html) function with a particular input value. I traced what I think is the problem to the [underlying C that the python library calls](https://github.com/ELIFE-ASU/Inform/blob/master/src/active_info.c).

In the underlying C, a [calloc()](https://www.tutorialspoint.com/c_standard_library/c_function_calloc.htm) call allocates memory based on the number of elements that need to be allocated. In my trigger case, I need to allocate over 2.5 billion elements. An example of cases that don't trigger require allocation of only 1.5 million. Importantly, I can run these trigger and non-trigger cases just fine on my local machine using Spyder. Could it be a memory issue?