### PR TITLE
Update processing of HbA1c values

### DIFF
--- a/RESHAPE/RESHAPE_check_HbA1c_SNOMED_codes.ipynb
+++ b/RESHAPE/RESHAPE_check_HbA1c_SNOMED_codes.ipynb
@@ -1,0 +1,418 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c6f8e413-c1d7-469f-bec1-46e8007828aa",
+   "metadata": {},
+   "source": [
+    "# Which SNOMED CT codes for HbA1c are useful?\n",
+    "\n",
+    "The purpose of this notebook is to figure out which of the SNOMED CT codes that relate to HbA1c are useful for the study of HbA1c values.\n",
+    "\n",
+    "The motivation for this purpose is that there are some strange results returned from a simple study of the numeric values that are returned from querying the [OpenSAFELY list of HbA1c SNOMED CT codes](https://www.opencodelists.org/codelist/opensafely/glycated-haemoglobin-hba1c-tests-numerical-value/). One would expect mmol/mol values between 40 and 80, typically, which approximately correspond to 5.8% to 9.5% in the percentage units. Instead, I am seeing values in the tens of thousands and values that are minus.\n",
+    "\n",
+    "In this notebook, I want to see if the problems are arising because of particular SNOMED CT codes, and see if my script to identify and convert the old percentage units into mmol/mol is performing correctly.\n",
+    "\n",
+    "(Note: The formula for converting the old percentage units to mmol/mol can be found, [here](https://ebmcalc.com/GlycemicAssessment.htm).)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32c9a535-b489-4e7d-b714-5d2d7c8839f4",
+   "metadata": {},
+   "source": [
+    "### Set up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "c30ee464-16ed-438e-ac97-f773c8f13b32",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if( !\"pacman\" %in% installed.packages() ){ install.packages( \"pacman\" ) }\n",
+    "pacman::p_load(\n",
+    "    bigrquery\n",
+    "    ,tidyverse\n",
+    "    )\n",
+    "\n",
+    "# Setup connection to GCP.\n",
+    "project_id = \"yhcr-prd-bradfor-bia-core\"\n",
+    "con <- DBI::dbConnect( drv = bigquery(), project = project_id ) %>% suppressWarnings()\n",
+    "\n",
+    "# Define R tibbles from GCP tables.\n",
+    "r_tbl_srcode <- dplyr::tbl( con, \"CB_FDM_PrimaryCare.tbl_srcode\" )\n",
+    "\n",
+    "# Define the list of SNOMED CT codes.\n",
+    "codes_SNOMED_test_of_interest <-\n",
+    "    readr::read_csv(file = paste0( 'codelists/', 'opensafely-glycated-haemoglobin-hba1c-tests-3e5b1269.csv' ),\n",
+    "                    col_types = cols( code = col_character(), term = col_character() ) )$code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dc893ea-8b69-42ab-b8d7-7e749b3a86b8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Distributional summary statistics without transformation to mmol/mol."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "97c23c7a-66c9-41dd-81dc-ba2d424832dc",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A tibble: 4 × 6</caption>\n",
+       "<thead>\n",
+       "\t<tr><th scope=col>snomedcode</th><th scope=col>n</th><th scope=col>max</th><th scope=col>mean</th><th scope=col>median</th><th scope=col>min</th></tr>\n",
+       "\t<tr><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>1003671000000109</td><td> 314378</td><td>27300</td><td> 5.308858761</td><td> 6.5</td><td>-8.9</td></tr>\n",
+       "\t<tr><td>1049301000000100</td><td>   4480</td><td>  144</td><td>42.781785714</td><td>41.0</td><td> 0.0</td></tr>\n",
+       "\t<tr><td>365845005       </td><td>   2612</td><td>    0</td><td>-0.005359877</td><td> 0.0</td><td>-1.0</td></tr>\n",
+       "\t<tr><td>999791000000106 </td><td>3020974</td><td>85000</td><td>48.637394356</td><td>42.0</td><td>-1.0</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A tibble: 4 × 6\n",
+       "\\begin{tabular}{llllll}\n",
+       " snomedcode & n & max & mean & median & min\\\\\n",
+       " <chr> & <int> & <dbl> & <dbl> & <dbl> & <dbl>\\\\\n",
+       "\\hline\n",
+       "\t 1003671000000109 &  314378 & 27300 &  5.308858761 &  6.5 & -8.9\\\\\n",
+       "\t 1049301000000100 &    4480 &   144 & 42.781785714 & 41.0 &  0.0\\\\\n",
+       "\t 365845005        &    2612 &     0 & -0.005359877 &  0.0 & -1.0\\\\\n",
+       "\t 999791000000106  & 3020974 & 85000 & 48.637394356 & 42.0 & -1.0\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A tibble: 4 × 6\n",
+       "\n",
+       "| snomedcode &lt;chr&gt; | n &lt;int&gt; | max &lt;dbl&gt; | mean &lt;dbl&gt; | median &lt;dbl&gt; | min &lt;dbl&gt; |\n",
+       "|---|---|---|---|---|---|\n",
+       "| 1003671000000109 |  314378 | 27300 |  5.308858761 |  6.5 | -8.9 |\n",
+       "| 1049301000000100 |    4480 |   144 | 42.781785714 | 41.0 |  0.0 |\n",
+       "| 365845005        |    2612 |     0 | -0.005359877 |  0.0 | -1.0 |\n",
+       "| 999791000000106  | 3020974 | 85000 | 48.637394356 | 42.0 | -1.0 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  snomedcode       n       max   mean         median min \n",
+       "1 1003671000000109  314378 27300  5.308858761  6.5   -8.9\n",
+       "2 1049301000000100    4480   144 42.781785714 41.0    0.0\n",
+       "3 365845005           2612     0 -0.005359877  0.0   -1.0\n",
+       "4 999791000000106  3020974 85000 48.637394356 42.0   -1.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Provide descriptive statistics of each SNOMED code.\n",
+    "r_tbl_srcode %>%\n",
+    "dplyr::select( person_id, dateevent, numericvalue, snomedcode ) %>%\n",
+    "dplyr::filter( snomedcode %in% codes_SNOMED_test_of_interest ) %>%\n",
+    "dplyr::collect() %>%\n",
+    "dplyr::group_by( snomedcode ) %>%\n",
+    "dplyr::summarise(\n",
+    "    n = n()\n",
+    "    ,max = max( numericvalue %>% as.numeric() )\n",
+    "    ,mean = mean( numericvalue %>% as.numeric() )\n",
+    "    ,median = numericvalue %>% as.numeric() %>% quantile( 0.5 )\n",
+    "    ,min = min( numericvalue %>% as.numeric() )\n",
+    ") %>%\n",
+    "dplyr::ungroup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "310b43ac-445a-4ba5-8e94-d1f3437c6c89",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Distributional summary statistics _with_ transformation to mmol/mol."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c8f79e73-758d-4a8b-b1c2-2bcef9e8afaa",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A tibble: 4 × 6</caption>\n",
+       "<thead>\n",
+       "\t<tr><th scope=col>snomedcode</th><th scope=col>n</th><th scope=col>max</th><th scope=col>mean</th><th scope=col>median</th><th scope=col>min</th></tr>\n",
+       "\t<tr><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>1003671000000109</td><td> 314378</td><td>27300.0000</td><td>37.503532839</td><td>44.26245</td><td>-120.76545</td></tr>\n",
+       "\t<tr><td>1049301000000100</td><td>   4480</td><td>  442.0781</td><td>44.285178549</td><td>41.00000</td><td>   0.00000</td></tr>\n",
+       "\t<tr><td>365845005       </td><td>   2612</td><td>    0.0000</td><td>-0.005359877</td><td> 0.00000</td><td>  -1.00000</td></tr>\n",
+       "\t<tr><td>999791000000106 </td><td>3020974</td><td>85000.0000</td><td>49.805432963</td><td>42.00000</td><td> -22.09844</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A tibble: 4 × 6\n",
+       "\\begin{tabular}{llllll}\n",
+       " snomedcode & n & max & mean & median & min\\\\\n",
+       " <chr> & <int> & <dbl> & <dbl> & <dbl> & <dbl>\\\\\n",
+       "\\hline\n",
+       "\t 1003671000000109 &  314378 & 27300.0000 & 37.503532839 & 44.26245 & -120.76545\\\\\n",
+       "\t 1049301000000100 &    4480 &   442.0781 & 44.285178549 & 41.00000 &    0.00000\\\\\n",
+       "\t 365845005        &    2612 &     0.0000 & -0.005359877 &  0.00000 &   -1.00000\\\\\n",
+       "\t 999791000000106  & 3020974 & 85000.0000 & 49.805432963 & 42.00000 &  -22.09844\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A tibble: 4 × 6\n",
+       "\n",
+       "| snomedcode &lt;chr&gt; | n &lt;int&gt; | max &lt;dbl&gt; | mean &lt;dbl&gt; | median &lt;dbl&gt; | min &lt;dbl&gt; |\n",
+       "|---|---|---|---|---|---|\n",
+       "| 1003671000000109 |  314378 | 27300.0000 | 37.503532839 | 44.26245 | -120.76545 |\n",
+       "| 1049301000000100 |    4480 |   442.0781 | 44.285178549 | 41.00000 |    0.00000 |\n",
+       "| 365845005        |    2612 |     0.0000 | -0.005359877 |  0.00000 |   -1.00000 |\n",
+       "| 999791000000106  | 3020974 | 85000.0000 | 49.805432963 | 42.00000 |  -22.09844 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  snomedcode       n       max        mean         median   min       \n",
+       "1 1003671000000109  314378 27300.0000 37.503532839 44.26245 -120.76545\n",
+       "2 1049301000000100    4480   442.0781 44.285178549 41.00000    0.00000\n",
+       "3 365845005           2612     0.0000 -0.005359877  0.00000   -1.00000\n",
+       "4 999791000000106  3020974 85000.0000 49.805432963 42.00000  -22.09844"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Provide descriptive statistics of each SNOMED code.\n",
+    "r_tbl_srcode %>%\n",
+    "dplyr::select( person_id, dateevent, numericvalue, snomedcode ) %>%\n",
+    "dplyr::filter( snomedcode %in% codes_SNOMED_test_of_interest ) %>%\n",
+    "dplyr::mutate(\n",
+    "        numericvalue = \n",
+    "            dplyr::if_else(\n",
+    "                sql(\"REGEXP_CONTAINS( numericvalue, r'\\\\.')\" )\n",
+    "                ,( numericvalue %>% as.numeric() %>% `-`( 2.15 ) ) %>% `*`( 10.929 ) %>% as.character()\n",
+    "                ,numericvalue\n",
+    "            )\n",
+    "    ) %>%\n",
+    "dplyr::collect() %>%\n",
+    "dplyr::group_by( snomedcode ) %>%\n",
+    "dplyr::summarise(\n",
+    "    n = n()\n",
+    "    ,max = max( numericvalue %>% as.numeric() )\n",
+    "    ,mean = mean( numericvalue %>% as.numeric() )\n",
+    "    ,median = numericvalue %>% as.numeric() %>% quantile( 0.5 )\n",
+    "    ,min = min( numericvalue %>% as.numeric() )\n",
+    ") %>%\n",
+    "dplyr::ungroup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b652d9e-8953-44fc-adbc-46fed7616f53",
+   "metadata": {},
+   "source": [
+    "### Discussion."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8e25f6c-e3ec-4172-b414-3a5a816185d8",
+   "metadata": {},
+   "source": [
+    "Firstly, I note that only four of the eleven SNOMED CT codes in the list are ever used in the Connected Bradford dataset.\n",
+    "\n",
+    "Secondly, conclude that:  \n",
+    "1. `1003671000000109` looks like old percentage values that the transformation corrects, but there are spuriously low initial values (e.g. -8.9) and high initial values (e.g. 27,3000).\n",
+    "    - ACTION: Keep, transform, bandpass-filter between 30 and some reasonable maximum.\n",
+    "2. `1049301000000100` looks like the standard mmol/mol value but the transformation is erroneously being applied to it, sometimes.\n",
+    "    - ACTION: Keep, do not transform, no need to apply filter but I will apply it so that everything is bounded in the same range.\n",
+    "3. `365845005` is nonsense\n",
+    "    - ACTION: Remove.   \n",
+    "4. `999791000000106`\n",
+    "    - ACTION: Keep, transform, bandpass-filter between 30 and some reasonable maximum."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e07ed83-35c6-406e-a328-83f33ff64eff",
+   "metadata": {},
+   "source": [
+    "### Apply new rules and check."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "d93388a1-c484-4be2-a0a9-c0baeae27492",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table class=\"dataframe\">\n",
+       "<caption>A tibble: 3 × 6</caption>\n",
+       "<thead>\n",
+       "\t<tr><th scope=col>snomedcode</th><th scope=col>n</th><th scope=col>max</th><th scope=col>mean</th><th scope=col>median</th><th scope=col>min</th></tr>\n",
+       "\t<tr><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;int&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>1003671000000109</td><td>    54</td><td> 98</td><td>52.24074</td><td>47</td><td>30</td></tr>\n",
+       "\t<tr><td>1049301000000100</td><td>  3648</td><td>100</td><td>48.77599</td><td>43</td><td>30</td></tr>\n",
+       "\t<tr><td>999791000000106 </td><td>807219</td><td>100</td><td>46.96400</td><td>42</td><td>30</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A tibble: 3 × 6\n",
+       "\\begin{tabular}{llllll}\n",
+       " snomedcode & n & max & mean & median & min\\\\\n",
+       " <chr> & <int> & <dbl> & <dbl> & <dbl> & <dbl>\\\\\n",
+       "\\hline\n",
+       "\t 1003671000000109 &     54 &  98 & 52.24074 & 47 & 30\\\\\n",
+       "\t 1049301000000100 &   3648 & 100 & 48.77599 & 43 & 30\\\\\n",
+       "\t 999791000000106  & 807219 & 100 & 46.96400 & 42 & 30\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A tibble: 3 × 6\n",
+       "\n",
+       "| snomedcode &lt;chr&gt; | n &lt;int&gt; | max &lt;dbl&gt; | mean &lt;dbl&gt; | median &lt;dbl&gt; | min &lt;dbl&gt; |\n",
+       "|---|---|---|---|---|---|\n",
+       "| 1003671000000109 |     54 |  98 | 52.24074 | 47 | 30 |\n",
+       "| 1049301000000100 |   3648 | 100 | 48.77599 | 43 | 30 |\n",
+       "| 999791000000106  | 807219 | 100 | 46.96400 | 42 | 30 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  snomedcode       n      max mean     median min\n",
+       "1 1003671000000109     54  98 52.24074 47     30 \n",
+       "2 1049301000000100   3648 100 48.77599 43     30 \n",
+       "3 999791000000106  807219 100 46.96400 42     30 "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Provide descriptive statistics of each SNOMED code.\n",
+    "r_tbl_srcode %>%\n",
+    "dplyr::select( person_id, dateevent, numericvalue, snomedcode ) %>%\n",
+    "dplyr::filter( snomedcode %in% codes_SNOMED_test_of_interest ) %>%\n",
+    "# Apply transformations, where appropriate\n",
+    "dplyr::mutate( numericvalue = numericvalue %>% as.numeric() ) %>%\n",
+    "dplyr::mutate(\n",
+    "        numericvalue = \n",
+    "            dplyr::case_when(\n",
+    "               snomedcode %in%\n",
+    "                    c( '1003671000000109'\n",
+    "                      ,'999791000000106' ) ~ numericvalue %>%\n",
+    "                                             `-`( 2.15 ) %>%\n",
+    "                                             `*`( 10.929 ) %>%\n",
+    "                                             round()\n",
+    "                ,snomedcode == '1049301000000100' ~ numericvalue\n",
+    "                ,snomedcode == '365845005' ~ NA\n",
+    "                \n",
+    "                ,TRUE ~ NA_character_\n",
+    "            )\n",
+    "    ) %>%\n",
+    "# Apply bandpass filter.\n",
+    "dplyr::mutate(\n",
+    "    numericvalue = \n",
+    "        dplyr::if_else(\n",
+    "            numericvalue < 30 | numericvalue > 100\n",
+    "            ,NA\n",
+    "            ,numericvalue )\n",
+    ") %>%\n",
+    "# Collect and summarise.\n",
+    "dplyr::collect() %>%\n",
+    "tidyr::drop_na() %>%\n",
+    "dplyr::group_by( snomedcode ) %>%\n",
+    "dplyr::summarise(\n",
+    "    n = n()\n",
+    "    ,max = max( numericvalue )\n",
+    "    ,mean = mean( numericvalue )\n",
+    "    ,median = numericvalue %>% quantile( 0.5 )\n",
+    "    ,min = min( numericvalue )\n",
+    ") %>%\n",
+    "dplyr::ungroup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9942ef4-355a-4f74-b129-823668f76658",
+   "metadata": {},
+   "source": [
+    "The new scripting rules provide sensible results. I will incorporate this into the `RESHAPE_cohort_generator.r` script."
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "ir",
+   "name": ".m115",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/:m115"
+  },
+  "kernelspec": {
+   "display_name": "R",
+   "language": "R",
+   "name": "ir"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "4.3.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I found spurious values of HbA1c. I updated the `tbl_srcode` object to remove the spurious HbA1c values, in `RESHAPE_cohort_generator.r`. The rationale and supporting substudy is in `RESHAPE_check_HbA1c_SNOMED_codes.ipynb`.