### PR TITLE
Update to H.M.A. calculation

### DIFF
--- a/RESHAPE/RESHAPE_create_STS_objects.r
+++ b/RESHAPE/RESHAPE_create_STS_objects.r
@@ -42,7 +42,7 @@ events_selection <-
 # Convert dataframe into a state sequence object for `TraMineR`.
 df_seq <-
     df_log_PandT_longFormat_simplified_StrataLabels %>%
-    dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
+    #dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
     dplyr::filter( event_value %in% events_selection ) %>%
     dplyr::group_by( person_id ) %>%
     dplyr::mutate( rn = row_number() ) %>%
@@ -92,7 +92,7 @@ events_selection <-
 # Convert dataframe into a state sequence object for `TraMineR`.
 df_seq_excludingUnobserved <-
     df_log_PandT_longFormat_simplified_StrataLabels %>%
-    dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
+    #dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
     dplyr::filter( event_value %in% events_selection ) %>%
     dplyr::group_by( person_id ) %>%
     dplyr::mutate( rn = row_number() ) %>%
@@ -148,7 +148,7 @@ events_selection <-
 # Convert dataframe into a state sequence object for `TraMineR`.
 df_seq_test_only <-
     df_log_PandT_longFormat_simplified_StrataLabels %>%
-    dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
+    #dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
     dplyr::filter( event_value %in% events_selection ) %>%
     dplyr::group_by( person_id ) %>%
     dplyr::mutate( rn = row_number() ) %>%
@@ -198,7 +198,7 @@ events_selection <-
 # Convert dataframe into a state sequence object for `TraMineR`.
 df_seq_test_only_excludingUnobserved <-
     df_log_PandT_longFormat_simplified_StrataLabels %>%
-    dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
+    #dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
     dplyr::filter( event_value %in% events_selection ) %>%
     dplyr::group_by( person_id ) %>%
     dplyr::mutate( rn = row_number() ) %>%
@@ -255,7 +255,7 @@ events_selection <-
 # Convert dataframe into a state sequence object for `TraMineR`.
 df_seq_intervention_only <-
     df_log_PandT_longFormat_simplified_StrataLabels %>%
-    dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
+    #dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
     dplyr::filter( event_value %in% events_selection ) %>%
     dplyr::group_by( person_id ) %>%
     dplyr::mutate( rn = row_number() ) %>%
@@ -305,7 +305,7 @@ events_selection <-
 # Convert dataframe into a state sequence object for `TraMineR`.
 df_seq_intervention_only_excludingUnobserved <-
     df_log_PandT_longFormat_simplified_StrataLabels %>%
-    dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
+    #dplyr::mutate_at( .vars = vars( event_value ), .funs = funs( as.factor ) ) %>%
     dplyr::filter( event_value %in% events_selection ) %>%
     dplyr::group_by( person_id ) %>%
     dplyr::mutate( rn = row_number() ) %>%


### PR DESCRIPTION
When calculating whether or not a patient record was indicating an Adjust state or not, the beginning of their observations would be Adjust by default because there was no prior prescription. I've change the syntax such that I look backward from the start of the observation window to figure out if the first-observed intertest interval is truly an Adjust or not.